### PR TITLE
print.ranef...(): do need `invisible(.)` {as the print(.) does has  `…

### DIFF
--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -116,6 +116,7 @@ print.ranef.glmmTMB <- function(x, simplify=TRUE, ...) {
     print(if (simplify && length(x$zi) == 0L)
               unclass(x$cond) else unclass(x),
           ...)
+    invisible(x)
 }
 
 


### PR DESCRIPTION
…unclass(x)`