### PR TITLE
Fix usesDispersion() in VarCorr.glmmTMB()

### DIFF
--- a/glmmTMB/R/VarCorr.R
+++ b/glmmTMB/R/VarCorr.R
@@ -78,9 +78,10 @@ VarCorr.glmmTMB <- function(x, sigma = 1, rdig = 3)# <- 3 args from nlme
     stopifnot(is.numeric(sigma), length(sigma) == 1)
     xrep <- x$obj$env$report()
     reT <- x$modelInfo$reTrms
+    familyStr <- family(x)$family
     useSc <- if (missing(sigma)) {
         sigma <- sigma(x)
-        usesDispersion(family(x)$family)
+        usesDispersion(familyStr)
     } else TRUE
 
     vc.cond <- if(length(cn <- reT$condList$cnms))
@@ -89,7 +90,7 @@ VarCorr.glmmTMB <- function(x, sigma = 1, rdig = 3)# <- 3 args from nlme
     vc.zi   <- if(length(cn <- reT$ziList$cnms))
         mkVC(cor = xrep$corzi, sd = xrep$sdzi, cnms = cn)
     structure(list(cond = vc.cond, zi = vc.zi),
-	      sc = usesDispersion(x), ## 'useScale'
+	      sc = usesDispersion(familyStr), ## 'useScale'
 	      class = "VarCorr.glmmTMB")
 }
 


### PR DESCRIPTION
Small bug with surprisingly large impact...

Before fix:
```
x <- rnorm(1e3)
y <- rnorm(1e3)+x
fit <- glmmTMB(y~x,se=TRUE)

system.time(print(fit))
   user  system elapsed 
 47.838   0.016  47.906
```

After fix:
```
system.time(print(fit))
   user  system elapsed 
   0.01    0.00    0.01
```
