### PR TITLE
Some optimizations:

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -10,13 +10,15 @@
 ##' @param family character
 ##' @param link character
 ##' @param ziPredictCode zero-inflation code
+##' @param doPredict flag to enable sds of predictions
 ##' @keywords internal
 ##' @importFrom stats model.offset
 mkTMBStruc <- function(formula, ziformula, dispformula,
                        mf, fr,
                        yobs, offset, weights,
                        family, link,
-                       ziPredictCode="corrected") {
+                       ziPredictCode="corrected",
+                       doPredict=0) {
 
   condList  <- getXReTrms(formula, mf, fr)
   ziList    <- getXReTrms(ziformula, mf, fr)
@@ -53,8 +55,8 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
     termszi = ziReStruc,
     family = .valid_family[family],
     link = .valid_link[link],
-    ziPredictCode = .valid_zipredictcode[ziPredictCode]
-
+    ziPredictCode = .valid_zipredictcode[ziPredictCode],
+    doPredict = doPredict
   )
   getVal <- function(obj, component)
     vapply(obj, function(x) x[[component]], numeric(1))
@@ -429,7 +431,6 @@ glmmTMB <- function (
     } else {
         sdr <- fitted <- NULL
     }
-    sdr <- if (se) sdreport(obj) else NULL
 
     modelInfo <- with(TMBStruc,
                       namedList(nobs, respCol, grpVar, familyStr, family, link,

--- a/glmmTMB/R/predict.R
+++ b/glmmTMB/R/predict.R
@@ -67,7 +67,8 @@ predict.glmmTMB <- function(object,newdata=NULL,debug=FALSE,
                          yobs=augFr[[names(respCol)]],
                          offset=NULL,weights=NULL,
                          family=familyStr,link=link,
-                         ziPredictCode=ziPredNm))
+                         ziPredictCode=ziPredNm,
+                         doPredict=1))
 
 
 

--- a/glmmTMB/src/glmmTMB.cpp
+++ b/glmmTMB/src/glmmTMB.cpp
@@ -216,7 +216,7 @@ Type allterms_nll(vector<Type> u, vector<Type> theta,
   Type ans = 0;
   int upointer = 0;
   int tpointer = 0;
-  int nr, np, offset;
+  int nr, np = 0, offset;
   for(int i=0; i < terms.size(); i++){
     nr = terms(i).blockSize * terms(i).blockReps;
     // Note: 'blockNumTheta=0' ==> Same parameters as previous term.
@@ -267,6 +267,7 @@ Type objective_function<Type>::operator() ()
   // Flags
   DATA_INTEGER(ziPredictCode);
   bool zi_flag = (betazi.size() > 0);
+  DATA_INTEGER(doPredict);
 
   // Joint negative log-likelihood
   Type jnll = 0;
@@ -388,7 +389,12 @@ Type objective_function<Type>::operator() ()
       error("Invalid 'ziPredictCode'");
     }
   }
-  ADREPORT(mu);
+
+  REPORT(mu);
+  // ADREPORT expensive for long vectors - only needed by predict()
+  // method. FIXME: May even consider reducing mu to some subset
+  // before ADREPORTing.
+  if (doPredict) ADREPORT(mu);
 
   return jnll;
 }


### PR DESCRIPTION
- ADREPORT should not be enabled by default. Can now run large datasets.
- glmmTMB: Don't call sdreport twice.
- Eliminate compiler warning.