### PR TITLE
Fix dispformula

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -328,9 +328,11 @@ okWeights <- function(x) {
 ##' formula; terms can also be added or subtracted. \strong{Offset terms
 ##' will automatically be dropped from the conditional effects formula.}
 ##' The zero-inflation model uses a logit link.
-##' @param dispformula combined fixed and random effects formula for dispersion:
-##'     the default \code{NULL} specifies no extra dispersion.  The dispersion model
-##' uses a log link.
+##' @param dispformula Fixed effects formula for dispersion: the
+##'     default \code{~1} specifies one dispersion parameter for
+##'     families that allow dispersion. The argument is ignored for
+##'     families that do not have a dispersion parameter. The
+##'     dispersion model uses a log link.
 ##' @param weights weights, as in \code{glm}. Only implemented for binomial and betabinomial families.
 ##' @param offset offset
 ##' @param se whether to return standard errors
@@ -363,7 +365,7 @@ glmmTMB <- function (
     data = NULL,
     family = gaussian(),
     ziformula = ~0,
-    dispformula= NULL,
+    dispformula= ~1,
     weights=NULL,
     offset=NULL,
     se=TRUE,

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -402,10 +402,6 @@ glmmTMB <- function (
     ## extract family and link information from family object
     link <- family$link
     familyStr <- family$family
-    
-    if (is.null(dispformula)) {
-      dispformula <- if (usesDispersion(familyStr)) ~1 else ~0
-    }
 
     ## lme4 function for warning about unused arguments in ...
     ## ignoreArgs <- c("start","verbose","devFunOnly",

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -38,6 +38,15 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
         betad_init <- 0
     }
 
+    ## Ignore 'dispformula' argument for non-dispersion families.
+    if ( ! usesDispersion(family) ) {
+        ## if ( dispformula != ~0 &&
+        ##      dispformula != ~1 )
+        ##     warning(sprintf("dispersion parameter ignored for family %s",
+        ##                     sQuote(family)))
+        dispformula <- ~0
+    }
+
     ## n.b. eval.parent() chain needs to be preserved because
     ## we are going to try to eval(mf) at the next level down,
     ## need to be able to find data etc.


### PR DESCRIPTION
This commit solves #194. 

TODO:

- Add test that updating from `nbinom` to `poisson` and back to `nbinom` does not change the fit (even if the nbinom uses a non-trivial `dispformula`).
