### PR TITLE
Printdispersion

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -666,9 +666,9 @@ print.summary.glmmTMB <- function(x, digits = max(3, getOption("digits") - 3),
             .prt.grps(x$ngrps[[nn]],nobs=x$nobs)
         }
     }
-
-    printDispersion(x$family,x$sigma)
-
+    if(length(x$sigma)==1) { #only print here if not printing dispersion model
+        printDispersion(x$family,x$sigma)
+    }
     for (nn in names(x$coefficients)) {
         cc <- x$coefficients[[nn]]
         p <- length(cc)

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -469,7 +469,7 @@ glmmTMB <- function (
     weights <- as.vector(model.weights(fr))
 
     if(!is.null(weights) & !okWeights(familyStr)) {
-      stop("'weights' are not available for this family. Try dispersion instead.")
+      stop("'weights' are not available for this family. See `dispformula` instead.")
     }
 
     if (is.null(weights)) weights <- rep(1,nobs)
@@ -666,7 +666,7 @@ print.summary.glmmTMB <- function(x, digits = max(3, getOption("digits") - 3),
             .prt.grps(x$ngrps[[nn]],nobs=x$nobs)
         }
     }
-    if(length(x$sigma)==1) { #only print here if not printing dispersion model
+    if(trivialDisp(x)) {# if trivial print here, else below(~x) or none(~0)
         printDispersion(x$family,x$sigma)
     }
     for (nn in names(x$coefficients)) {

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -385,7 +385,7 @@ printDispersion <- function(ff,s) {
             sval <- s^2
         } else {
             dname <- "Overdispersion parameter"
-            sname <- "sigma"
+            sname <- ""
             sval <- s
         }            
         cat(sprintf("\n%s for %s family (%s): %s",

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -33,11 +33,11 @@ cNames <- list(cond = "Conditional model",
 ## FIXME: this is a bit ugly. On the other hand, a single-parameter
 ## dispersion model without a
 trivialDisp <- function(object) {
+    ## This version works on summary object or fitted model object
     ## FIXME: is there a better way to strip the environment before
     ## comparing?
-    identical(deparse(object$modelInfo$allForm$dispformula),"~1")
+    identical(deparse(object$call$dispformula),"~1")
 }
-
 trivialFixef <- function(xnm,nm) {
     length(xnm)==0 ||
         (nm %in% c('d','disp') && identical(xnm,'(Intercept)'))

--- a/glmmTMB/man/Salamanders.Rd
+++ b/glmmTMB/man/Salamanders.Rd
@@ -14,7 +14,7 @@
 	\item{mined}{factor indicating whether the site was affected by mountian top removal coal mining} 
 	\item{cover}{amount of cover objects in the stream (scaled)} 
 	\item{sample}{repeated sample}
-	\item{DOP}{Day of sampling period}
+	\item{DOP}{Days since precipitation (scaled)}
 	\item{Wtemp}{water temperature (scaled)}
 	\item{DOY}{day of year (scaled)}
 	\item{spp}{abreviated species name, possibly also life stage}

--- a/glmmTMB/man/glmmTMB.Rd
+++ b/glmmTMB/man/glmmTMB.Rd
@@ -31,9 +31,8 @@ formula; terms can also be added or subtracted. \strong{Offset terms
 will automatically be dropped from the conditional effects formula.}
 The zero-inflation model uses a logit link.}
 
-\item{dispformula}{combined fixed and random effects formula for dispersion:
-    the default \code{NULL} specifies no extra dispersion.  The dispersion model
-uses a log link.}
+\item{dispformula}{formula for dispersion (fixed effects only):
+    the default \code{~1} does the standard dispersion given the family. See details.}
 
 \item{weights}{weights, as in \code{glm}. Only implemented for binomial and betabinomial families.}
 
@@ -55,6 +54,7 @@ Fit models with TMB
 must be specified in the form \code{prob ~ ..., weights = N} rather than in
 the more typical two-column matrix (\code{cbind(successes,failures)~...}) form.
 \item in all cases \code{glmmTMB} returns maximum likelihood estimates - random effects variance-covariance matrices are not REML (so use \code{REML=FALSE} when comparing with \code{lme4::lmer}), and residual standard deviations (\code{\link{sigma}}) are not bias-corrected. Because the \code{\link{df.residual}} method for \code{glmmTMB} currently counts the dispersion parameter, one would need to multiply by \code{sqrt(nobs(fit)/(1+df.residual(fit)))} when comparing with \code{lm} ...
+\item For an explanation of the dispersion parameter for each family, see (\code{\link{sigma}}). In models with a \code{dispfomula} depending on variables, a log link is used and output for the \code{Dispersion model} should be interpreted accordinly. In Gaussian mixed models, it is possible to fix the variance parameter at 0 using \code{dispformula=~0}, thus forcing all variance into the random effects.
 }
 }
 \examples{


### PR DESCRIPTION
It always seemed weird to me to call the overdispersion parameter "sigma" for all families, so I removed that from the summary output. I found the explanation of the `sigma()` function to be very helpful for interpreting overdispersion parameters. So I point to it in the details of the description of `dispformula` in the glmmTMB helpfile (someone might want to read it and make sure it makes sense). I wonder if it would be clearer (it would for me) if `sigma()` was renamed `dispersion()`. 

Soon, I also want to edit the examples in the helpfile to include nbinom and ZI since those features will be the attractor for many new users. Maybe we could include examples of the RE structures with simulated data, to give an idea of what the RE structures mean.