### PR TITLE
Simulate from random effects

### DIFF
--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -626,11 +626,10 @@ fitted.glmmTMB <- function(object, ...) {
     predict(object)
 }
 
-.noSimFamilies <- c("beta", "betabinomial", "truncated_poisson", 
-"truncated_nbinom1", "truncated_nbinom2")
+.noSimFamilies <- c("beta", "betabinomial")
 
 noSim <- function(x) {
-	!is.na(match(x, .noSimFamilies))
+    !is.na(match(x, .noSimFamilies))
 }
 
 ##' Simulate from a glmmTMB fitted model
@@ -646,15 +645,11 @@ noSim <- function(x) {
 ##' @importFrom stats simulate
 ##' @export
 simulate.glmmTMB<-function(object, nsim=1, seed=NULL, ...){
- if(noSim(object$modelInfo$family$family))
- {
- 	stop("Simulation code has not been implemented for this family")
- }
- ret <- list()
- if(!is.null(seed)) set.seed(seed)
- for (i in 1:nsim)
- {
-   ret[[i]] <- object$obj$simulate()$yobs
- }
- ret
+    if(noSim(object$modelInfo$family$family))
+    {
+    	stop("Simulation code has not been implemented for this family")
+    }
+    if(!is.null(seed)) set.seed(seed)
+    ret <- replicate(nsim, object$obj$simulate()$yobs, simplify=FALSE)
+    ret
 }

--- a/glmmTMB/src/glmmTMB.cpp
+++ b/glmmTMB/src/glmmTMB.cpp
@@ -91,13 +91,13 @@ namespace glmmtmb{
   }
 
 }
-//Quantile functions needed to simulate from truncated distributions
+
+/* Quantile functions needed to simulate from truncated distributions */
 extern "C" {
-  double Rf_qnbinom(double p, double sz, double pb);
+  double Rf_qnbinom(double p, double size, double prob, int lower_tail, int log_p);
+  double Rf_qpois(double p, double lambda, int lower_tail, int log_p);
 }
-extern "C" {
-  double Rf_qpois(double p, double mu);
-}
+
 enum valid_family {
   gaussian_family = 0,
   binomial_family = 100,
@@ -585,7 +585,7 @@ Type objective_function<Type>::operator() ()
           SIMULATE{
             s1 = mu(i)/phi(i);//sz
             s2 = 1/(1+phi(i)); //pb
-            yobs(i) = Rf_qnbinom(asDouble(runif(dnbinom(Type(0), s1, s2), Type(1))), asDouble(s1), asDouble(s2));
+            yobs(i) = Rf_qnbinom(asDouble(runif(dnbinom(Type(0), s1, s2), Type(1))), asDouble(s1), asDouble(s2), 1, 0);
           }
         }
         break;
@@ -611,7 +611,7 @@ Type objective_function<Type>::operator() ()
           SIMULATE{
             s1 = phi(i); //sz
             s2 = phi(i)/(phi(i)+mu(i)); //pb
-            yobs(i) = Rf_qnbinom(asDouble(runif(dnbinom(Type(0), s1, s2), Type(1))), asDouble(s1), asDouble(s2));
+            yobs(i) = Rf_qnbinom(asDouble(runif(dnbinom(Type(0), s1, s2), Type(1))), asDouble(s1), asDouble(s2), 1, 0);
           }
         }
         break;
@@ -626,7 +626,7 @@ Type objective_function<Type>::operator() ()
         log_nzprob = logspace_sub(Type(0), -mu(i));
         tmp_loglik = dpois(yobs(i), mu(i), true) - log_nzprob;
         SIMULATE{
-          yobs(i) = Rf_qpois(asDouble(runif(dpois(Type(0), mu(i)), Type(1))), asDouble(mu(i)));
+          yobs(i) = Rf_qpois(asDouble(runif(dpois(Type(0), mu(i)), Type(1))), asDouble(mu(i)), 1, 0);
         }
         break;
       default:


### PR DESCRIPTION
This is a continuation of branch 'simulate_truncated' that now also simulates 'b' and 'bzi' vectors.
Truncated simulators are correct as far as I can tell - still need testing.
