### PR TITLE
Mollie

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -573,9 +573,19 @@ glmmTMB <- function (
     } else {
         sdr <- NULL
     }
-    if(!is.null(sdr$pdHess))if(!sdr$pdHess) warning(paste0("Model convergence problem; non-positive-definite Hessian matrix. ", 
-                             "See vignette('troubleshooting')".)
-	
+    if(!is.null(sdr$pdHess)) {
+      if(!sdr$pdHess) {
+        warning(paste0("Model convergence problem; non-positive-definite Hessian matrix. ", 
+                       "See vignette('troubleshooting')"))
+      } else {
+        eigval <- 1/eigen(sdr$cov.fixed)$values
+        if(min(eigval) < .Machine$double.eps*10) {
+          warning(paste0("Model convergence problem; very small eigen values detected. ", 
+                       "See vignette('troubleshooting')"))
+        }
+      }
+    }
+
     modelInfo <- with(TMBStruc,
                       namedList(nobs, respCol, grpVar, familyStr, family, link,
                                 ## FIXME:apply condList -> cond earlier?

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -575,12 +575,14 @@ glmmTMB <- function (
     }
     if(!is.null(sdr$pdHess)) {
       if(!sdr$pdHess) {
-        warning(paste0("Model convergence problem; non-positive-definite Hessian matrix. ", 
+        warning(paste0("Model convergence problem; ",
+                       "non-positive-definite Hessian matrix. ", 
                        "See vignette('troubleshooting')"))
       } else {
-        eigval <- 1/eigen(sdr$cov.fixed)$values
-        if(min(eigval) < .Machine$double.eps*10) {
-          warning(paste0("Model convergence problem; very small eigen values detected. ", 
+        eigval <- try(1/eigen(sdr$cov.fixed)$values, silent=TRUE)
+        if( is(eigval, "try-error") || ( min(eigval) < .Machine$double.eps*10 ) ) {
+          warning(paste0("Model convergence problem; ",
+                       "extreme or very small eigen values detected. ", 
                        "See vignette('troubleshooting')"))
         }
       }

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -538,6 +538,9 @@ glmmTMB <- function (
     ##  may cause downstream problems, e.g. with predict()
     y <- as.numeric(y)
     
+   if (grepl("^truncated", family$family) & (any(y<1)) & (ziformula == ~0))
+        stop(paste0("'", names(respCol), "'", " contains zeros (or values below the allowable range). ",
+             "Zeros are compatible with a trucated distribution only when zero-inflation is added."))
 
     TMBStruc <- 
         mkTMBStruc(formula, ziformula, dispformula,

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -573,8 +573,8 @@ glmmTMB <- function (
     } else {
         sdr <- NULL
     }
-    if(!is.null(sdr$pdHess))if(!sdr$pdHess) warning(paste0("Model convergence problem. Hessian is not positive definite. ", 
-                             "This may indicate that a model is overparameterized."))
+    if(!is.null(sdr$pdHess))if(!sdr$pdHess) warning(paste0("Model convergence problem; non-positive-definite Hessian matrix. ", 
+                             "See vignette('troubleshooting')".)
 	
     modelInfo <- with(TMBStruc,
                       namedList(nobs, respCol, grpVar, familyStr, family, link,

--- a/glmmTMB/tests/testthat/test-families.R
+++ b/glmmTMB/tests/testthat/test-families.R
@@ -129,10 +129,9 @@ test_that("truncated", {
     ## Truncated poisson with zeros => invalid:
     num_zeros <- 10
     z_tp0 <<- c(rep(0, num_zeros), z_tp)
-    g1_tp0 <- glmmTMB(z_tp0~1,family=list(family="truncated_poisson",
+    expect_error(g1_tp0 <- glmmTMB(z_tp0~1,family=list(family="truncated_poisson",
                                           link="log"),
-                      data=data.frame(z_tp0))
-    expect_false( is.finite(logLik(g1_tp0)) )
+                      data=data.frame(z_tp0)))
     ## Truncated poisson with zeros and zero-inflation:
     g1_tp0 <- glmmTMB(z_tp0~1,family=list(family="truncated_poisson",
                                           link="log"),
@@ -158,10 +157,9 @@ test_that("truncated", {
     ## Truncated nbinom2 with zeros => invalid:
     num_zeros <- 10
     z_nb0 <<- c(rep(0, num_zeros), z_nb)
-    g1_nb0 <- glmmTMB(z_nb0~1,family=list(family="truncated_nbinom2",
+    expect_error(g1_nb0 <- glmmTMB(z_nb0~1,family=list(family="truncated_nbinom2",
                                           link="log"),
-                      data=data.frame(z_nb0))
-    expect_false( is.finite(logLik(g1_nb0)) )
+                      data=data.frame(z_nb0)))
     ## Truncated nbinom2 with zeros and zero-inflation:
     g1_nb0 <- glmmTMB(z_nb0~1,family=list(family="truncated_nbinom2",
                                           link="log"),
@@ -184,10 +182,9 @@ test_that("truncated", {
     expect_equal(c(unname(fixef(g1_nb1)[[1]]),sigma(g1_nb1)),
                  c(1.980207,3.826909),tol=1e-5)
     ## Truncated nbinom1 with zeros => invalid:
-    g1_nb0 <- glmmTMB(z_nb0~1,family=list(family="truncated_nbinom1",
+    expect_error(g1_nb0 <- glmmTMB(z_nb0~1,family=list(family="truncated_nbinom1",
                                           link="log"),
-                      data=data.frame(z_nb0))
-    expect_false( is.finite(logLik(g1_nb0)) )
+                      data=data.frame(z_nb0)))
     ## Truncated nbinom2 with zeros and zero-inflation:
     g1_nb0 <- glmmTMB(z_nb0~1,family=list(family="truncated_nbinom1",
                                           link="log"),

--- a/glmmTMB/vignettes/troubleshooting.rmd
+++ b/glmmTMB/vignettes/troubleshooting.rmd
@@ -1,0 +1,52 @@
+---
+title: "Troubleshooting with glmmTMB"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{troubleshooting}
+  %\VignetteEngine{knitr::rmarkdown}
+  \usepackage[utf8]{inputenc}
+---
+
+```{r echo=FALSE}
+library(glmmTMB)
+```
+
+This vignette covers common problems that occur while using `glmmTMB`. 
+The contents will expand with experience.
+
+#Warnings
+
+##Non-Positive-Definite Hessian matrix
+After your model is fit, you may see the same warning in the following example
+```{r non-pos-def}
+zinbm0 = glmmTMB(count~spp +(1|site), zi=~spp, Salamanders, family="nbinom2")
+```
+This often occurs when a model is overparameterized (i.e. the data does not contain information to estimate the parameters).
+However, in the example above, the problem is that the model doesn't capture the main pattern in the data where zero observations do not depend on species as in `zi=~spp`; rather, they depend on another covariate that is missing from the model `minded`. 
+Plotting the data against potential covariates should help to avoid fitting unreasonable models that don't converge.
+
+In some cases, scaling predictor variables may help.
+
+Models with non-positive definite Hessian matricies should be excluded from further consideration, in general.  
+
+##nlminb(start = par, objective = fn, gradient = gr): NA/NaN function evaluation
+This warning often occurs when the optimizer wanders into a region of parameter space that is invalid. 
+It is not a problem as long as the optimizer has left that region of parameter space upon convergence, which is indicated by an absence of the model convergence warnings described above. 
+
+##Cholmod warning 'matrix not positive definite'
+
+#Errors
+
+##nlminb(start = par, objective = fn, gradient = gr): gradient function must return a numeric
+This error can occur when the data do not conform to the specified distribution. 
+
+
+
+```{r echo=FALSE, eval=FALSE}
+#FIXME
+#What's going on with this model?
+#cov.fixed is full of NaN
+m1=glmmTMB(count~spp + mined + (1|site), zi=~spp + mined, Salamanders, family="genpois")
+```
+

--- a/glmmTMB/vignettes/troubleshooting.rmd
+++ b/glmmTMB/vignettes/troubleshooting.rmd
@@ -30,22 +30,28 @@ In some cases, scaling predictor variables may help.
 
 Models with non-positive definite Hessian matricies should be excluded from further consideration, in general.  
 
-##nlminb(start = par, objective = fn, gradient = gr): NA/NaN function evaluation
+##`nlminb(start = par, objective = fn, gradient = gr): NA/NaN function evaluation`
 This warning often occurs when the optimizer wanders into a region of parameter space that is invalid. 
 It is not a problem as long as the optimizer has left that region of parameter space upon convergence, which is indicated by an absence of the model convergence warnings described above. 
 
-##Cholmod warning 'matrix not positive definite'
-
 #Errors
 
-##nlminb(start = par, objective = fn, gradient = gr): gradient function must return a numeric
+##`nlminb(start = par, objective = fn, gradient = gr): gradient function must return a numeric vector of length`
 This error can occur when the data do not conform to the specified distribution. 
 
+#To be documented (preferably with repeatable examples)
+
+##`nlminb(start = par, objective = fn, gradient = gr) NA/NaN gradient evaluation`
+
+##`Cholmod warning 'matrix not positive definite'`
+
+##`Error in optimHess(par.fixed, obj$fn, obj$gr): gradient in optim evaluated to length`
+?same as "nlminb(start = par, objective = fn, gradient = gr): gradient function must return a numeric vector of length" ?
 
 
 ```{r echo=FALSE, eval=FALSE}
 #FIXME
-#What's going on with this model?
+#What's going on with this model? (besides the genpois distribution being tempermental)
 #cov.fixed is full of NaN
 m1=glmmTMB(count~spp + mined + (1|site), zi=~spp + mined, Salamanders, family="genpois")
 ```

--- a/glmmTMB/vignettes/troubleshooting.rmd
+++ b/glmmTMB/vignettes/troubleshooting.rmd
@@ -15,12 +15,14 @@ library(glmmTMB)
 This vignette covers common problems that occur while using `glmmTMB`. 
 The contents will expand with experience.
 
+If your problem is not covered below, try updating to the latest version of `glmmTMB` on GitHub. The developers might have solved the problem in a newer version. 
+
 #Warnings
 
-##Non-Positive-Definite Hessian matrix
-After your model is fit, you may see the same warning in the following example
+##Model convergence problem; non-positive-definite Hessian matrix
+After your model is fit, you may see the same warning as in the following example:
 ```{r non-pos-def}
-zinbm0 = glmmTMB(count~spp +(1|site), zi=~spp, Salamanders, family="nbinom2")
+zinbm0 = glmmTMB(count~spp + (1|site), zi=~spp, Salamanders, family="nbinom2")
 ```
 This often occurs when a model is overparameterized (i.e. the data does not contain information to estimate the parameters).
 However, in the example above, the problem is that the model doesn't capture the main pattern in the data where zero observations do not depend on species as in `zi=~spp`; rather, they depend on another covariate that is missing from the model `minded`. 
@@ -30,29 +32,42 @@ In some cases, scaling predictor variables may help.
 
 Models with non-positive definite Hessian matricies should be excluded from further consideration, in general.  
 
-##`nlminb(start = par, objective = fn, gradient = gr): NA/NaN function evaluation`
-This warning often occurs when the optimizer wanders into a region of parameter space that is invalid. 
-It is not a problem as long as the optimizer has left that region of parameter space upon convergence, which is indicated by an absence of the model convergence warnings described above. 
+##Model convergence problem; Eigen value problems
+```{r genpois NaN}
+m1 = glmmTMB(count~spp + mined + (1|site), zi=~spp + mined, Salamanders, family="genpois")
+```
+In this example, the fixed effect covariance matrix is `NaN`. It may have to do with the generalized Poisson distribution, which is known to have convergence problems (luckily, the negative binomial and/or Conway-Maxwell Poisson are good alternatives). 
+
+Models with convergence problems should be excluded from further consideration, in general.
+
+##NA/NaN function evaluation
+```{r NA function, eval=FALSE}
+Warning in nlminb(start = par, objective = fn, gradient = gr) :
+  NA/NaN function evaluation
+```
+This warning often occurs when the optimizer wanders into a region of parameter space that is invalid. It is not a problem as long as the optimizer has left that region of parameter space upon convergence, which is indicated by an absence of the model convergence warnings described above. 
 
 #Errors
 
-##`nlminb(start = par, objective = fn, gradient = gr): gradient function must return a numeric vector of length`
-This error can occur when the data do not conform to the specified distribution. 
+## gradient function must return a numeric vector of length...
+```{r gradient length, eval=FALSE}
+Error in nlminb(start = par, objective = fn, gradient = gr) : 
+  gradient function must return a numeric vector of length x
+```
 
-#To be documented (preferably with repeatable examples)
+This error can occur when the response variable does not conform to the specified distribution. 
+
+#To be documented 
+(preferably with short repeatable examples)
 
 ##`nlminb(start = par, objective = fn, gradient = gr) NA/NaN gradient evaluation`
 
 ##`Cholmod warning 'matrix not positive definite'`
+?similar to `Warning in nlminb(start = par, objective = fn, gradient = gr): NA/NaN function evaluation`?
 
 ##`Error in optimHess(par.fixed, obj$fn, obj$gr): gradient in optim evaluated to length`
-?same as "nlminb(start = par, objective = fn, gradient = gr): gradient function must return a numeric vector of length" ?
+?similar to `nlminb(start = par, objective = fn, gradient = gr): gradient function must return a numeric vector of length` ?
 
 
-```{r echo=FALSE, eval=FALSE}
-#FIXME
-#What's going on with this model? (besides the genpois distribution being tempermental)
-#cov.fixed is full of NaN
-m1=glmmTMB(count~spp + mined + (1|site), zi=~spp + mined, Salamanders, family="genpois")
-```
+
 

--- a/misc/problematic/unconverged_salamanders.R
+++ b/misc/problematic/unconverged_salamanders.R
@@ -17,3 +17,6 @@ zinb1m3,
 zinb1m4,
 zinb1m5,
 zinb2m3)
+
+#Genpois (this distribution is known for poor convergence)
+m1=glmmTMB(count~spp + mined + (1|site), zi=~spp + mined, Salamanders, family="genpois")


### PR DESCRIPTION
- initial troubleshooting vignette (needs work)
- warning refers to troubleshooting vignette
- warn when eigen values are small or NA
- stop for zeros in trunc dist without zi

Passes `check --as-cran`. 
Only tested new warning on troubleshooting vignette examples; more examples needed.