### PR TITLE
predict.glmmTMB updates

### DIFF
--- a/glmmTMB/R/predict.R
+++ b/glmmTMB/R/predict.R
@@ -156,7 +156,8 @@ predict.glmmTMB <- function(object,newdata=NULL,
       H <- with(object,optimHess(oldPar,obj$fn,obj$gr))
       ## FIXME: Eventually add 'getReportCovariance=FALSE' to this sdreport
       ##        call to fix memory issue (requires recent TMB version)
-      sdr <- sdreport(newObj,oldPar,hessian.fixed=H)
+      ## Fixed! (but do we want a flag to get it ? ...)
+      sdr <- sdreport(newObj,oldPar,hessian.fixed=H,getReportCovariance=FALSE)
       pred <- summary(sdr, "report") ## TMB:::summary.sdreport(sdr, "report")
       return(list(fit=pred[,"Estimate"],
                   se.fit=pred[,"Std. Error"]))

--- a/glmmTMB/R/predict.R
+++ b/glmmTMB/R/predict.R
@@ -70,6 +70,10 @@ assertIdenticalModels <- function(data.tmb1, data.tmb0, allow.new.levels=FALSE)
 ##' data(sleepstudy,package="lme4")
 ##' g0 <- glmmTMB(Reaction~Days+(Days|Subject),sleepstudy)
 ##' predict(g0, sleepstudy)
+##' ## Predict new Subject
+##' nd <- sleepstudy[1,]
+##' nd$Subject <- "new"
+##' predict(g0, newdata=nd, allow.new.levels=TRUE)
 ##' @importFrom TMB sdreport
 ##' @importFrom stats optimHess
 ##' @export

--- a/glmmTMB/R/predict.R
+++ b/glmmTMB/R/predict.R
@@ -59,11 +59,13 @@ assertIdenticalModels <- function(data.tmb1, data.tmb0, allow.new.levels=FALSE)
 ##' the mean of the conditional distribution ("conditional": mu),
 ##' or the probability of a structural zero ("zprob")?
 ##' @param debug (logical) return the \code{TMBStruc} object that will be
-##' used internally for debuggin?
+##' used internally for debugging?
 ##' @param re.form (not yet implemented) specify which random effects to condition on when predicting
-##' @param allow.new.levels (not yet implemented) allow previously unobserved levels in random-effects grouping variables?
+##' @param allow.new.levels allow previously unobserved levels in random-effects variables? see details.
 ##' @param \dots unused - for method compatibility
-
+##' @details
+##' Prediction of new random effect levels is possible as long as the model specification (fixed effects and parameters) is kept constant.
+##' However, to ensure intentional usage, a warning is triggered if \code{allow.new.levels=FALSE} (the default).
 ##' @examples
 ##' data(sleepstudy,package="lme4")
 ##' g0 <- glmmTMB(Reaction~Days+(Days|Subject),sleepstudy)

--- a/glmmTMB/tests/testthat/test-predict.R
+++ b/glmmTMB/tests/testthat/test-predict.R
@@ -1,0 +1,29 @@
+stopifnot(require("testthat"),
+          require("glmmTMB"))
+
+data(sleepstudy,
+     package = "lme4")
+sleepstudy <- transform(sleepstudy, DaysFac = factor(cut(Days,2)) )
+
+## 'newdata'
+nd <- subset(sleepstudy, Subject=="308", select=-1)
+nd$Subject <- "new"
+nd$DaysFac <- "new"
+
+context("Predicting new levels")
+
+g0 <- glmmTMB(Reaction ~ Days + (Days|Subject), sleepstudy)
+prnd <- predict(g0, newdata=nd, allow.new.levels=TRUE)
+expect_equal( as.numeric(prnd),
+              fixef(g0)$cond[1] + fixef(g0)$cond[2] * nd$Days , tol=1e-10)
+
+context("Catch invalid predictions")
+
+g1 <- glmmTMB(Reaction ~ Days + Subject, sleepstudy)
+expect_error( predict(g1, nd) )   ## Error: Requires unknown fixed effect 'Subjectnew'
+
+g2 <- glmmTMB(Reaction ~ us(DaysFac | Subject), sleepstudy)
+expect_error( predict(g2, nd) )   ## Error: Not OK due to new parameters
+
+g3 <- glmmTMB(Reaction ~ ar1(DaysFac + 0| Subject), sleepstudy)
+expect_warning( predict(g3, nd) ) ## OK: AR1 does not introduce new parameters


### PR DESCRIPTION
* Add checks to guard against invalid predictions #222.
* Enable the predict argument `allow.new.levels=FALSE`. By default a warning is thrown if predicting new levels.
