### PR TITLE
allow method="[Ww]ald" in confint.glmmTMB

### DIFF
--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -602,6 +602,7 @@ format.perc <- function (probs, digits) {
 ##' }
 confint.glmmTMB <- function (object, parm, level = 0.95,
                              method=c("wald",
+                                      "Wald",
                                       "profile",
                                       "uniroot"),
                              component = c("all", "cond", "zi", "other"),
@@ -611,7 +612,7 @@ confint.glmmTMB <- function (object, parm, level = 0.95,
                              cl = NULL,
                              ...)
 {
-    method <- match.arg(method)
+    method <- tolower(match.arg(method))
     if (method=="wald") {
         dots <- list(...)
         if (length(dots)>0) {

--- a/glmmTMB/man/confint.glmmTMB.Rd
+++ b/glmmTMB/man/confint.glmmTMB.Rd
@@ -5,7 +5,7 @@
 \title{Calculate confidence intervals}
 \usage{
 \method{confint}{glmmTMB}(object, parm, level = 0.95, method = c("wald",
-  "profile", "uniroot"), component = c("all", "cond", "zi", "other"),
+  "Wald", "profile", "uniroot"), component = c("all", "cond", "zi", "other"),
   estimate = TRUE, parallel = c("no", "multicore", "snow"),
   ncpus = getOption("profile.ncpus", 1L), cl = NULL, ...)
 }

--- a/glmmTMB/tests/testthat/test-methods.R
+++ b/glmmTMB/tests/testthat/test-methods.R
@@ -148,6 +148,7 @@ test_that("confint", {
                   .Dimnames = list(c("cond.(Intercept)", "cond.Days"),
                                    c("2.5 %", "97.5 %"))),
         tolerance=1e-6)
+    ciw <- confint(fm2, 1:2, method="Wald", estimate=FALSE)
     expect_warning(confint(fm2,type="junk"),
                    "extra arguments ignored")
     ## Gamma test Std.Dev and sigma


### PR DESCRIPTION
I'm not sure this is necessary/a good idea.  There was some confusion on my part: the `broom.mixed` method for tidying `glmmTMB` objects was using "Wald" rather than "wald". Don't know whether we should allow this sloppiness, change the default to "Wald" (which is what `lme4` uses), or leave it as is.