### PR TITLE
Link fix

### DIFF
--- a/glmmTMB/R/family.R
+++ b/glmmTMB/R/family.R
@@ -186,6 +186,16 @@ tweedie <- function(link="log") {
     return(make_family(r,link))
 }
 
+## t not yet implemented in 
+## t_family <- function(link="identity") {
+##     ## FIXME: right now t behaves just like gaussian(); variance()
+##     ## returns a value *proportional* to the variance
+##     r <- list(family="t",link=link,
+##               variance=function(mu) {
+##         rep.int(1,length(mu))
+##     })
+## }
+
 #' List model options that glmmTMB knows about
 #'
 #' @note these are all the options that are \emph{defined} internally; they have not necessarily all been \emph{implemented} (FIXME!)

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -48,6 +48,9 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
   if (!is(family,"family")) {
       ## if family specified as list, not result of function ...
       ## special case for beta models
+      if (is.list(family)) {
+          warning("specifying ",sQuote("family")," as a plain list is deprecated")
+      }
       if (is.character(family)) {
           fname <- family
           args <- NULL
@@ -56,7 +59,7 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
           args <- family["link"]
       }
       if (fname=="beta") fname <- "beta_family"
-      ff <- try(do.call(fname,args))
+      ff <- try(do.call(fname,args),silent=TRUE)
       if (!inherits(ff,"try-error")) {
           family <- ff
       } else {
@@ -423,14 +426,7 @@ binomialType <- function(x) {
 ##' @param formula combined fixed and random effects formula, following lme4
 ##'     syntax
 ##' @param data data frame
-##' @param family family (variance/link function) information; see \code{\link{family}} for
-##' generic family details or \code{\link{family_glmmTMB}} for details of \code{glmmTMB} specific families.  
-##' As in \code{\link{glm}}, \code{family} can be specified as (1) a character string
-##' referencing an existing family-construction function (e.g. \sQuote{"binomial"}); (2) a symbol referencing
-##' such a function (\sQuote{binomial}); or (3) the output of such a function (\sQuote{binomial()}).
-##' In addition, for families such as \code{betabinomial} that are special to \code{glmmTMB}, family
-##' can be specified as (4) a list comprising the name of the distribution and the link function
-##' (\sQuote{list(family="binomial", link="logit")}). However, the first 3 options are preferable.
+##' @param family a family function, a character string naming a family function, or the result of a call to a family function family (variance/link function) information; see \code{\link{family}} for generic discussion of families or \code{\link{family_glmmTMB}} for details of \code{glmmTMB}-specific families.
 ##' @param ziformula a \emph{one-sided} (i.e., no response variable) formula for
 ##'     zero-inflation combining fixed and random effects:
 ##' the default \code{~0} specifies no zero-inflation.
@@ -479,6 +475,7 @@ binomialType <- function(x) {
 ##' \item \code{toep} (* Toeplitz)
 ##' }
 ##' (note structures marked with * are experimental/untested)
+##' \item For backward compatibility, the \code{family} argument can also be specified as a list comprising the name of the distribution and the link function (e.g. \sQuote{list(family="binomial", link="logit")}). However, \strong{this alternatives is now deprecated} (it produces a warning and will be removed at some point in the future). Furthermore, certain capabilities such as Pearson residuals or predictions on the data scale will only be possible if components such as \code{variance} and \code{linkfun} are present (see \code{\link{family}}).
 ##' }
 ##' @useDynLib glmmTMB
 ##' @importFrom stats update

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -14,7 +14,7 @@
       function) is now deprecated.
     }
   }
-}x
+}
 
 \section{CHANGES IN VERSION 0.2.1}{
   \subsection{NEW FEATURES}{

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -4,6 +4,17 @@
 \title{glmmTMB News}
 \encoding{UTF-8}
 
+\section{CHANGES IN VERSION 0.2.1.9000}{
+  \subsection{USER-VISIBLE CHANGES}
+  \itemize{
+    \item Because family functions are now available for all
+    families that have been implemented in the underlying TMB
+    code, specifying the \code{family} argument as a raw list (rather than as a family
+    function, the name of a family function, or the output of such a
+    function) is now deprecated.
+  }
+}
+
 \section{CHANGES IN VERSION 0.2.1}{
   \subsection{NEW FEATURES}{
     \itemize{

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -5,15 +5,16 @@
 \encoding{UTF-8}
 
 \section{CHANGES IN VERSION 0.2.1.9000}{
-  \subsection{USER-VISIBLE CHANGES}
-  \itemize{
-    \item Because family functions are now available for all
-    families that have been implemented in the underlying TMB
-    code, specifying the \code{family} argument as a raw list (rather than as a family
-    function, the name of a family function, or the output of such a
-    function) is now deprecated.
+  \subsection{USER-VISIBLE CHANGES}{
+    \itemize{
+      \item Because family functions are now available for all
+      families that have been implemented in the underlying TMB
+      code, specifying the \code{family} argument as a raw list (rather than as a family
+      function, the name of a family function, or the output of such a
+      function) is now deprecated.
+    }
   }
-}
+}x
 
 \section{CHANGES IN VERSION 0.2.1}{
   \subsection{NEW FEATURES}{

--- a/glmmTMB/man/Owls.Rd
+++ b/glmmTMB/man/Owls.Rd
@@ -47,8 +47,7 @@ dotplot(reorder(Nest,NegPerChick) ~ NegPerChick| FoodTreatment:SexParent,
 ## Fit negative binomial model with "constant" Zero Inflation :
 owls_nb1 <- glmmTMB(SiblingNegotiation ~ FoodTreatment*SexParent +
                                     (1|Nest)+offset(log(BroodSize)),
-              family = list(family="nbinom1",link="log"),
-              zi = ~1, data=Owls)
+              family = nbinom1(), zi = ~1, data=Owls)
 owls_nb1_bs <- update(owls_nb1,
                       . ~ . - offset(log(BroodSize)) + log(BroodSize))
 fixef(owls_nb1_bs)

--- a/glmmTMB/man/epil2.Rd
+++ b/glmmTMB/man/epil2.Rd
@@ -36,7 +36,7 @@
 epil2$subject <- factor(epil2$subject)
 op <- options(digits=3)
 (fm <- glmmTMB(y ~ Base*trt + Age + Visit + (Visit|subject),
-              data=epil2, family=list(family="nbinom2",link="log")))
+              data=epil2, family=nbinom2))
 meths <- methods(class = class(fm))
 if((Rv <- getRversion()) > "3.1.3") {
     (funs <- attr(meths, "info")[, "generic"])

--- a/glmmTMB/tests/testthat/test-basics.R
+++ b/glmmTMB/tests/testthat/test-basics.R
@@ -110,12 +110,14 @@ test_that("Multiple RE, reordering", {
 
 test_that("Alternative family specifications [via update(.)]", {
     ## intercept-only fixed effect
-    
-    expect_equal(gm0, matchForm(gm0, update(gm0, family= "binomial")))
+
+    res_chr <- matchForm(gm0, update(gm0, family= "binomial"))
+    expect_equal(gm0, res_chr)
     expect_equal(gm0, matchForm(gm0, update(gm0, family= binomial())))
-    expect_equal(gm0, matchForm(gm0, update(gm0, family= list(family = "binomial",
+    expect_warning(res_list <- matchForm(gm0, update(gm0, family= list(family = "binomial",
                                                        link = "logit")),
-                              family=TRUE))
+                                         family=TRUE))
+    expect_equal(gm0, res_list)
 })
 
 test_that("Update Binomial", {
@@ -239,8 +241,8 @@ test_that("NA handling", {
 
 quine.nb1 <- MASS::glm.nb(Days ~ Sex/(Age + Eth*Lrn), data = quine)
 quine.nb2 <- glmmTMB(Days ~ Sex/(Age + Eth*Lrn), data = quine,
-                     family=list(family="nbinom2",link="log"))
+                     family=nbinom2())
 quine.nb3 <- glmmTMB(Days ~ Sex + (1|Age), data = quine,
-                     family=list(family="nbinom2",link="log"))
+                     family=nbinom2())
 
 ## FIX ME: need to actually test these things!

--- a/glmmTMB/tests/testthat/test-families.R
+++ b/glmmTMB/tests/testthat/test-families.R
@@ -78,8 +78,11 @@ test_that("beta", {
                  tol=1e-5)
     expect_equal(c(VarCorr(m1)[[1]][[1]]),
                  0.433230926800709, tol=1e-5)
-    m2 <- update(m1,family=beta_family())
+    ## allow family="beta", but with warning
+    expect_warning(m2 <- glmmTMB(y~x+(1|f),family="beta",
+                  data=dd),"please use")
     expect_equal(coef(summary(m1)),coef(summary(m2)))
+    
  })
 
 test_that("nbinom", {

--- a/glmmTMB/tests/testthat/test-zi.R
+++ b/glmmTMB/tests/testthat/test-zi.R
@@ -12,7 +12,7 @@ test_that("zi", {
     ## Fit negative binomial model with "constant" Zero Inflation :
     owls_nb1 <<- glmmTMB(SiblingNegotiation ~ FoodTreatment*SexParent +
                              (1|Nest)+offset(log(BroodSize)),
-                         family = list(family="nbinom1",link="log"),
+                         family = nbinom1(),
                          ziformula = ~1, data=Owls)
     owls_nb2 <<- update(owls_nb1,
                         ziformula = ~ FoodTreatment*SexParent + (1|Nest))

--- a/glmmTMB/vignettes/glmmTMB.Rnw
+++ b/glmmTMB/vignettes/glmmTMB.Rnw
@@ -85,7 +85,7 @@ In order to fit a model in \code{glmmTMB} you need to:
   of nested random effects (block within site) would be
   \code{1|site/block}; a model of crossed random effects
   (block and year) would be \code{(1|block)+(1|year)}.
-  \item choose the error distribution by specifying the family (\code{family} argument). In general, you can specify the function (\code{binomial}, \code{gaussian}, \code{poisson}, \code{Gamma} from base R, or one of the options listed at \code{family_glmmTMB} [\code{nbinom2}, \code{beta_family()}, \code{betabinomial}, \ldots])).
+  \item choose the error distribution by specifying the family (\code{family} argument). In general, you can specify the function (\code{binomial}, \code{gaussian}, \code{poisson}, \code{Gamma} from base R, or one of the options listed at \code{family\_glmmTMB} [\code{nbinom2}, \code{beta_family()}, \code{betabinomial}, \ldots])).
 \item choose the error distribution by specifying the family (\code{family} argument). For standard GLM families implemented in R, you can use the function name (\code{binomial}, \code{gaussian}, \code{poisson}, \code{Gamma}). Otherwise, you should specify the family argument as a list containing (at least) the (character) elements \code{family} and \code{link}, e.g. \code{family=list(family="nbinom2",link="log")}.
 \item optionally specify a zero-inflation model (via the \code{ziformula} argument) with fixed and/or random effects
 \item optionally specify a dispersion model with fixed effects

--- a/glmmTMB/vignettes/glmmTMB.Rnw
+++ b/glmmTMB/vignettes/glmmTMB.Rnw
@@ -85,7 +85,7 @@ In order to fit a model in \code{glmmTMB} you need to:
   of nested random effects (block within site) would be
   \code{1|site/block}; a model of crossed random effects
   (block and year) would be \code{(1|block)+(1|year)}.
-  \item choose the error distribution by specifying the family (\code{family} argument). In general, you can specify the function (\code{binomial}, \code{gaussian}, \code{poisson}, \code{Gamma} from base R, or one of the options listed at \code{family\_glmmTMB} [\code{nbinom2}, \code{beta_family()}, \code{betabinomial}, \ldots])).
+  \item choose the error distribution by specifying the family (\code{family} argument). In general, you can specify the function (\code{binomial}, \code{gaussian}, \code{poisson}, \code{Gamma} from base R, or one of the options listed at \code{family\_glmmTMB} [\code{nbinom2}, \code{beta\_family()}, \code{betabinomial}, \ldots])).
 \item choose the error distribution by specifying the family (\code{family} argument). For standard GLM families implemented in R, you can use the function name (\code{binomial}, \code{gaussian}, \code{poisson}, \code{Gamma}). Otherwise, you should specify the family argument as a list containing (at least) the (character) elements \code{family} and \code{link}, e.g. \code{family=list(family="nbinom2",link="log")}.
 \item optionally specify a zero-inflation model (via the \code{ziformula} argument) with fixed and/or random effects
 \item optionally specify a dispersion model with fixed effects

--- a/glmmTMB/vignettes/glmmTMB.Rnw
+++ b/glmmTMB/vignettes/glmmTMB.Rnw
@@ -85,6 +85,7 @@ In order to fit a model in \code{glmmTMB} you need to:
   of nested random effects (block within site) would be
   \code{1|site/block}; a model of crossed random effects
   (block and year) would be \code{(1|block)+(1|year)}.
+  \item choose the error distribution by specifying the family (\code{family} argument). In general, you can specify the function (\code{binomial}, \code{gaussian}, \code{poisson}, \code{Gamma} from base R, or one of the options listed at \code{family_glmmTMB} [\code{nbinom2}, \code{beta_family()}, \code{betabinomial}, \ldots])).
 \item choose the error distribution by specifying the family (\code{family} argument). For standard GLM families implemented in R, you can use the function name (\code{binomial}, \code{gaussian}, \code{poisson}, \code{Gamma}). Otherwise, you should specify the family argument as a list containing (at least) the (character) elements \code{family} and \code{link}, e.g. \code{family=list(family="nbinom2",link="log")}.
 \item optionally specify a zero-inflation model (via the \code{ziformula} argument) with fixed and/or random effects
 \item optionally specify a dispersion model with fixed effects

--- a/glmmTMB/vignettes/miscEx.rmd
+++ b/glmmTMB/vignettes/miscEx.rmd
@@ -30,7 +30,7 @@ Fit models:
 ```{r modbeta1}
 ## location only
 m1 <- glmmTMB(y~x,
-              family=list(family="beta",link="logit"),
+              family=beta_family(),
               data=dd)
 ## add model for dispersion
 m2 <- update(m1,dispformula=~x)

--- a/glmmTMB/vignettes/timingFuns.R
+++ b/glmmTMB/vignettes/timingFuns.R
@@ -1,7 +1,7 @@
 
 ## run model & extract elapsed time
 form0 <- use ~ urban+age+livch+(urban|district)
-tt <- function(fun,data,form=form0,family="binomial",debug=FALSE) {
+tt <- function(fun,data,form=form0,family=binomial,debug=FALSE) {
     argList <- list(form,data)
     if (!is.null(family)) argList <- c(argList,list(family=family))
     unname(system.time(do.call(fun,argList))["elapsed"])
@@ -11,7 +11,7 @@ tt <- function(fun,data,form=form0,family="binomial",debug=FALSE) {
 ## of the data
 getTimes <- function(n=1,which=c("glmmTMB","glmer"),
                      basedata=Contraception,form=form0,
-                     family="binomial",
+                     family=binomial,
                      debug=FALSE) {
   if (n>1) {
     if (!n==round(n)) stop("only integer magnification allowed")

--- a/glmmTMB/vignettes/troubleshooting.rmd
+++ b/glmmTMB/vignettes/troubleshooting.rmd
@@ -23,7 +23,7 @@ If your problem is not covered below, try updating to the latest version of `glm
 
 You may see the same warning as in the following example:
 ```{r non-pos-def,cache=TRUE}
-zinbm0 = glmmTMB(count~spp + (1|site), zi=~spp, Salamanders, family="nbinom2")
+zinbm0 = glmmTMB(count~spp + (1|site), zi=~spp, Salamanders, family=nbinom2)
 ```
 
 This error states that the point that `glmmTMB` has identified as the putative maximum-likelihood estimate, the curvature of the log-likelihood surface does not seem to be consistent with `glmmTMB` really having found a maximum: instead, it is upward-curving, or flat, in some direction(s).
@@ -85,7 +85,7 @@ VarCorr(zinbm0_B)
 ```
 
 <!-- FIXME: updating here does weird things
-zinbm1 = update(zinbm0, ziformula=~mined, Salamanders, family="nbinom2")
+zinbm1 = update(zinbm0, ziformula=~mined, Salamanders, family=nbinom2)
 -->
 
 The original analysis considered variation in zero-inflation by site status
@@ -94,7 +94,7 @@ to estimate two parameters (mined + difference between mined and no-mining)
 rather than 7 (one per species) for the zero-inflation model.
 
 ```{r zinbm1,cache=TRUE}
-zinbm1 = glmmTMB(count~spp + (1|site), zi=~mined, Salamanders, family="nbinom2")
+zinbm1 = glmmTMB(count~spp + (1|site), zi=~mined, Salamanders, family=nbinom2)
 fixef(zinbm1)[["zi"]]
 ```
 
@@ -125,7 +125,7 @@ In general models with non-positive definite Hessian matrices should be excluded
 ##Model convergence problem:  eigenvalue problems
 
 ```{r genpois_NaN,cache=TRUE}
-m1 = glmmTMB(count~spp + mined + (1|site), zi=~spp + mined, Salamanders, family="genpois")
+m1 = glmmTMB(count~spp + mined + (1|site), zi=~spp + mined, Salamanders, family=genpois)
 ```
 
 In this example, the fixed-effect covariance matrix is `NaN`. It may have to do with the generalized Poisson (`genpois`) distribution, which is known to have convergence problems; luckily, the negative binomial (`nbinom1` and `nbinom2`) and/or Conway-Maxwell Poisson (`compois`) are good alternatives. 
@@ -154,7 +154,7 @@ Warning in f(par, order = order, ...) : value out of range in 'lgamma'
 
 ```{r NA gradient, error=TRUE, warning=FALSE}
 dat1 = expand.grid(y=-1:1, rep=1:10)
-m1 = glmmTMB(y~1, dat1, family="nbinom2")
+m1 = glmmTMB(y~1, dat1, family=nbinom2)
 ```
 The error occurs here because the negative binomial distribution is not appropriate for data with negative values.
 


### PR DESCRIPTION
I decided to deprecate only the list-format. Dealing with the other formats (character, function, list of class "family") is not actually that hard.  Added one special case, which is that `family="beta"` gets handled correctly but with a warning ...