### PR TITLE
removed mu=mu in predict uncorrected_zipredictcode

### DIFF
--- a/glmmTMB/src/glmmTMB.cpp
+++ b/glmmTMB/src/glmmTMB.cpp
@@ -842,7 +842,7 @@ Type objective_function<Type>::operator() ()
       mu *= (Type(1) - pz); // Account for zi in prediction
       break;
     case uncorrected_zipredictcode:
-      mu = mu; // Predict mean of 'family'
+      //mu = mu; // Predict mean of 'family' //comented out for clang 7.0.0. with no effect
       break;
     case prob_zipredictcode:
       mu = pz; // Predict zi probability


### PR DESCRIPTION
Fixes a warning that will occur when clang 7.0.0 is released http://www.stats.ox.ac.uk/pub/bdr/clang7/glmmTMB.out

I confirmed that `test-predict.R` includes `predict(...type="conditional")` which should check that predictions are not affected by this change.