### PR TITLE
Fix covstruct order

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -261,10 +261,13 @@ getXReTrms <- function(formula, mf, fr, ranOK=TRUE, type="", contrasts) {
 
         mf$formula <- ranform
         reTrms <- mkReTrms(findbars(RHSForm(formula)), fr)
+        order.reTrms <- names(reTrms$Ztlist)
 
         ss <- splitForm(formula)
+        order.ss <- sapply(ss$reTrmFormulas,deparse)
         ss <- unlist(ss$reTrmClasses)
 
+        ss <- ss[match(order.ss, order.reTrms)]
         Z <- t(reTrms$Zt)   ## still sparse ...
     }
 

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -272,7 +272,9 @@ getXReTrms <- function(formula, mf, fr, ranOK=TRUE, type="", contrasts) {
         if (length(unique(order.ss)) != length(order.ss))
             stop("Random effect terms arguments must be unique")
 
-        ss <- ss[match(order.ss, order.reTrms)]
+        perm <- match(order.reTrms, order.ss)
+        stopifnot( identical(order.ss[perm], order.reTrms) )
+        ss <- ss[perm]
         Z <- t(reTrms$Zt)   ## still sparse ...
     }
 

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -267,6 +267,11 @@ getXReTrms <- function(formula, mf, fr, ranOK=TRUE, type="", contrasts) {
         order.ss <- sapply(ss$reTrmFormulas,deparse)
         ss <- unlist(ss$reTrmClasses)
 
+        ## Example: ar1(1|Block) + us(1|Block) would return
+        ## order.ss = c("1|Block", "1|Block") which would break the match.
+        if (length(unique(order.ss)) != length(order.ss))
+            stop("Random effect terms arguments must be unique")
+
         ss <- ss[match(order.ss, order.reTrms)]
         Z <- t(reTrms$Zt)   ## still sparse ...
     }

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -3,7 +3,22 @@
 \name{NEWS}
 \title{glmmTMB News}
 \encoding{UTF-8}
-
+\section{CHANGES IN VERSION 0.2.3}{
+  \subsection{NEW FEATURES}{
+    \itemize{
+    }
+  }
+  \subsection{USER-VISIBLE CHANGES}{
+    \itemize{
+    }
+  }
+  \subsection{BUG FIXES}{
+    \itemize{
+    	\item models with multiple types of RE (e.g. ar1 and us) 
+    	may have failed previously (GH #329)
+    }
+  }
+}    	
 \section{CHANGES IN VERSION 0.2.2}{
   \subsection{NEW FEATURES}{
     \itemize{


### PR DESCRIPTION
fixes #329 which had nothing to do with the nesting (there was confusion caused by (1|A/B)).