### PR TITLE
Ranef 2grp fix

### DIFF
--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -164,7 +164,7 @@ ranef.glmmTMB <- function(object, condVar=TRUE, ...) {
           if (!is.null(sd)) {
               ## attach conditional variance info
               ## called "condVar", *not* "postVar" (contrast to lme4)
-              attr(d, "condVar") <- if (sum(w <- (asgn==i))>1) {
+              attr(d, "condVar") <- if (length(w <- which(asgn==i))>1) {
                                         ## FIXME: set names?
                                         sd[w]  ## if more than one term, list
                                   } else sd[[w]]  ## else just the array

--- a/glmmTMB/tests/testthat/test-VarCorr.R
+++ b/glmmTMB/tests/testthat/test-VarCorr.R
@@ -27,12 +27,12 @@ stripTMBVC <- function(x) {
     return(r)
 }
 expect_equal(stripTMBVC(fm1),unclass(VarCorr(fm1C)),
-             tol=1e-3)
+             tol=2e-3)
 expect_equal(stripTMBVC(gm1),unclass(VarCorr(gm1C)),
              tol=5e-3)
 ## have to take only last 4 lines
 ## some white space diffs introduced in fancy-corr-printing
-pfun <- function(x) squash_white(capture.output(print(VarCorr(x),digits=3)))
+pfun <- function(x) squash_white(capture.output(print(VarCorr(x),digits=2)))
 expect_equal(tail(pfun(fm1),4),
              pfun(fm1C))
 

--- a/glmmTMB/tests/testthat/test-families.R
+++ b/glmmTMB/tests/testthat/test-families.R
@@ -236,8 +236,10 @@ test_that("truncated", {
                       data=data.frame(z_nb0))
     expect_equal( plogis(as.numeric(fixef(g1_nb0)$zi)), num_zeros/length(z_nb0), tol=1e-7 ) ## Test zero-prob
     expect_equal(fixef(g1_nb0)$cond, fixef(g1_nb1)$cond, tol=1e-6) ## Test conditional model
+})
 
-    #Genpois
+##Genpois
+test_that("genpois",{
     tgp1 <<- glmmTMB(z_nb ~1, data=data.frame(z_nb), family=truncated_genpois())
     tgpdat <<- data.frame(y=simulate(tgp1)[,1])
     tgp2 <<- glmmTMB(y ~1, tgpdat, family=truncated_genpois())
@@ -247,8 +249,12 @@ test_that("truncated", {
     expect_lt(sigma(tgp1), confint(tgp2)["sigma", "97.5 %"])
     expect_lt(confint(tgp2)["cond.(Intercept)", "2.5 %"], unname(fixef(tgp1)$cond[1]))
     expect_lt(unname(fixef(tgp1)$cond[1]), confint(tgp2)["cond.(Intercept)", "97.5 %"])
+})
 
-    #Compois
+
+context("compois/genpois/tweedie")
+##Compois
+test_that("trunc compois",{
     tcmp1 <<- glmmTMB(z_nb ~1, data=data.frame(z_nb), family=truncated_compois())
     tcmpdat <<- data.frame(y=simulate(tcmp1)[,1])
     tcmp2 <<- glmmTMB(y ~1, tcmpdat, family=truncated_compois())		

--- a/glmmTMB/tests/testthat/test-families.R
+++ b/glmmTMB/tests/testthat/test-families.R
@@ -252,7 +252,7 @@ test_that("genpois",{
 })
 
 
-context("compois/genpois/tweedie")
+context("trunc compois")
 ##Compois
 test_that("trunc compois",{
     tcmp1 <<- glmmTMB(z_nb ~1, data=data.frame(z_nb), family=truncated_compois())
@@ -265,6 +265,8 @@ test_that("trunc compois",{
     expect_lt(confint(tcmp2)["cond.(Intercept)", "2.5 %"], unname(fixef(tcmp1)$cond[1]))
     expect_lt(unname(fixef(tcmp1)$cond[1]), confint(tcmp2)["cond.(Intercept)", "97.5 %"])
 })
+
+context("compois")
 test_that("compois", {
 	cmpdat <<- data.frame(f=factor(rep(c('a','b'), 10)),
 	 			y=c(15,5,20,7,19,7,19,7,19,6,19,10,20,8,21,8,22,7,20,8))
@@ -273,6 +275,8 @@ test_that("compois", {
 	expect_equal(sigma(cmp1), 0.1833339, tol=1e-6)
 	expect_equal(predict(cmp1,type="response")[1:2], c(19.4, 7.3), tol=1e-6)
 })
+
+context("genpois")
 test_that("genpois", {
 	gendat <<- data.frame(y=c(11,10,9,10,9,8,11,7,9,9,9,8,11,10,11,9,10,7,13,9))
 	gen1 <<- glmmTMB(y~1, family=genpois(), gendat)
@@ -280,6 +284,7 @@ test_that("genpois", {
 	expect_equal(sigma(gen1), 0.235309, tol=1e-6)
 })
 
+context("tweedie")
 test_that("tweedie", {
     ## Boiled down tweedie:::rtweedie :
     rtweedie <- function (n, xi = power, mu, phi, power = NULL)

--- a/glmmTMB/tests/testthat/test-methods.R
+++ b/glmmTMB/tests/testthat/test-methods.R
@@ -1,7 +1,7 @@
 stopifnot(require("testthat"),
           require("glmmTMB"))
 
-data(sleepstudy, cbpp,
+data(sleepstudy, cbpp, Pastes,
      package = "lme4")
 
 if (getRversion() < "3.3.0") {
@@ -32,6 +32,10 @@ fm3ZIP <- update(fm2, round(Reaction) ~ ., family=poisson,
                  ziformula=~(1|Subject))
 ## separate-terms model
 fm2diag2   <- update(fm2, . ~ Days + (1| Subject)+ (0+Days|Subject))
+
+## model with two different grouping variables
+fmP <- glmmTMB(strength ~ cask + (1|batch) + (1|sample), data=Pastes)
+
 context("basic methods")
 
 test_that("Fitted and residuals", {
@@ -290,3 +294,9 @@ cond.19      cond Subject        Days 308 9.236420  2.699692
 "),
 tolerance=1e-5)
   })
+
+test_that("ranef(.) works with more than one grouping factor",
+{
+    expect_equal(names(ranef(fmP)[["cond"]]), c("sample","batch"))
+    expect_equal(dim(as.data.frame(ranef(fmP))), c(40,6))
+})

--- a/glmmTMB/tests/testthat/test-reml.R
+++ b/glmmTMB/tests/testthat/test-reml.R
@@ -12,9 +12,9 @@ test_that("REML check against lmer", {
                            sleepstudy, REML=TRUE)
     expect_equal( logLik(fm1.lmer) , logLik(fm1.glmmTMB) )
     expect_equal(as.vector(predict(fm1.lmer)) ,
-                 predict(fm1.glmmTMB), tol=1e-6)
+                 predict(fm1.glmmTMB), tolerance=2e-3)
     expect_equal(vcov(fm1.glmmTMB)$cond,
-                 as.matrix(vcov(fm1.lmer)) , tol=1e-4)
+                 as.matrix(vcov(fm1.lmer)) , tolerance=1e-3)
     ## Example 2: Compare results with lmer
     data(Orthodont,package="nlme")
     Orthodont$nsex <- as.numeric(Orthodont$Sex=="Male")
@@ -23,9 +23,9 @@ test_that("REML check against lmer", {
                          (0 + nsexage|Subject), data=Orthodont, REML=TRUE)
     fm2.glmmTMB <- glmmTMB(distance ~ age + (age|Subject) + (0+nsex|Subject) +
                                (0 + nsexage|Subject), data=Orthodont, REML=TRUE)
-    expect_equal( logLik(fm2.lmer) , logLik(fm2.glmmTMB) )
+    expect_equal( logLik(fm2.lmer) , logLik(fm2.glmmTMB), tolerance=1e-5 )
     expect_equal(as.vector(predict(fm2.lmer)) ,
-                 predict(fm2.glmmTMB), tol=1e-6)
+                 predict(fm2.glmmTMB), tolerance=1e-4)
     expect_equal(vcov(fm2.glmmTMB)$cond,
-                 as.matrix(vcov(fm2.lmer)) , tol=1e-4)
+                 as.matrix(vcov(fm2.lmer)) , tolerance=1e-3)
 })


### PR DESCRIPTION
this PR addresses https://github.com/glmmTMB/glmmTMB/issues/396 ; it also loosens some test tolerances (anticipating possible changes in lme4 that change numeric outcomes slightly), and adds some extra labels to some of the exotic-family tests