### PR TITLE
shortened truncated_compois test

### DIFF
--- a/glmmTMB/tests/testthat/test-families.R
+++ b/glmmTMB/tests/testthat/test-families.R
@@ -239,7 +239,7 @@ test_that("truncated", {
 })
 
 ##Genpois
-test_that("genpois",{
+test_that("truncated_genpois",{
     tgp1 <<- glmmTMB(z_nb ~1, data=data.frame(z_nb), family=truncated_genpois())
     tgpdat <<- data.frame(y=simulate(tgp1)[,1])
     tgp2 <<- glmmTMB(y ~1, tgpdat, family=truncated_genpois())
@@ -254,22 +254,19 @@ test_that("genpois",{
 
 context("trunc compois")
 ##Compois
-test_that("trunc compois",{
-    tcmp1 <<- glmmTMB(z_nb ~1, data=data.frame(z_nb), family=truncated_compois())
-    tcmpdat <<- data.frame(y=simulate(tcmp1)[,1])
-    tcmp2 <<- glmmTMB(y ~1, tcmpdat, family=truncated_compois())		
-    expect_equal(sigma(tcmp1), sigma(tcmp2), tol=1e-1)
-    expect_equal(fixef(tcmp1)$cond[1], fixef(tcmp2)$cond[1], tol=1e-2)
-    expect_lt(confint(tcmp2)["sigma", "2.5 %"], sigma(tcmp1))
-    expect_lt(sigma(tcmp1), confint(tcmp2)["sigma", "97.5 %"])
-    expect_lt(confint(tcmp2)["cond.(Intercept)", "2.5 %"], unname(fixef(tcmp1)$cond[1]))
-    expect_lt(unname(fixef(tcmp1)$cond[1]), confint(tcmp2)["cond.(Intercept)", "97.5 %"])
+test_that("truncated_compois",{
+	cmpdat <<- data.frame(f=factor(rep(c('a','b'), 10)),
+	 			y=c(15,5,20,7,19,7,19,7,19,6,19,10,20,8,21,8,22,7,20,8))
+	tcmp1 <<- glmmTMB(y~f, cmpdat, family= truncated_compois())
+	expect_equal(unname(fixef(tcmp1)$cond), c(2.9652730653, -0.9773987194), tol=1e-6)
+	expect_equal(sigma(tcmp1), 0.1833339, tol=1e-6)
+	expect_equal(predict(tcmp1,type="response")[1:2], c(19.4, 7.3), tol=1e-6)    
 })
 
 context("compois")
 test_that("compois", {
-	cmpdat <<- data.frame(f=factor(rep(c('a','b'), 10)),
-	 			y=c(15,5,20,7,19,7,19,7,19,6,19,10,20,8,21,8,22,7,20,8))
+#	cmpdat <<- data.frame(f=factor(rep(c('a','b'), 10)),
+#	 			y=c(15,5,20,7,19,7,19,7,19,6,19,10,20,8,21,8,22,7,20,8))
 	cmp1 <<- glmmTMB(y~f, cmpdat, family=compois())
 	expect_equal(unname(fixef(cmp1)$cond), c(2.9652730653, -0.9773987194), tol=1e-6)
 	expect_equal(sigma(cmp1), 0.1833339, tol=1e-6)


### PR DESCRIPTION
fixes #397. The compois test data are underdipsersed enough and far enough above zero that they can also be used for the truncated_compois test.