### PR TITLE
preliminary fix for data-dependent bases

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -223,7 +223,10 @@ getXReTrms <- function(formula, mf, fr, ranOK=TRUE, type="", contrasts) {
         identical(RHSForm(fixedform), ~ -1)) {
         X <- NULL
     } else {
-        mf$formula <- fixedform
+        tt <- terms(fixedform)
+        pv <- attr(mf$formula,"predvars")
+        attr(tt, "predvars") <- fix_predvars(pv,tt)
+        mf$formula <- tt
         terms_fixed <- terms(eval(mf,envir=environment(fixedform)))
         ## FIXME: make model matrix sparse?? i.e. Matrix:::sparse.model.matrix()
         X <- model.matrix(drop.special2(fixedform), fr, contrasts)

--- a/glmmTMB/R/predict.R
+++ b/glmmTMB/R/predict.R
@@ -123,11 +123,14 @@ predict.glmmTMB <- function(object,newdata=NULL,
 
   mf$drop.unused.levels <- TRUE
   mf[[1]] <- as.name("model.frame")
-  mf$formula <- RHSForm(object$modelInfo$allForm$combForm, as.form=TRUE)
+  tt <- terms(RHSForm(object$modelInfo$allForm$combForm, as.form=TRUE))
+  pv <- attr(terms(object),"predvars")
+  attr(tt,"predvars") <- fix_predvars(pv,tt)
+  mf$formula <- tt
     
   if (is.null(newdata)) {
     mf$data <- mc$data ## restore original data
-    newFr <- object$fr
+    newFr <- object$frame
   } else {
     mf$data <- newdata
     mf$na.action <- na.action

--- a/glmmTMB/R/predict.R
+++ b/glmmTMB/R/predict.R
@@ -123,10 +123,10 @@ predict.glmmTMB <- function(object,newdata=NULL,
 
   mf$drop.unused.levels <- TRUE
   mf[[1]] <- as.name("model.frame")
-  tt <- terms(RHSForm(object$modelInfo$allForm$combForm, as.form=TRUE))
+  tt <- terms(object$modelInfo$allForm$combForm)
   pv <- attr(terms(object),"predvars")
   attr(tt,"predvars") <- fix_predvars(pv,tt)
-  mf$formula <- tt
+  mf$formula <- RHSForm(tt, as.form=TRUE)
     
   if (is.null(newdata)) {
     mf$data <- mc$data ## restore original data

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -560,3 +560,27 @@ get_cor <- function(theta) {
     cc <- Dh %*% cL %*% Dh
     return(cc[lower.tri(cc)])
 }
+
+## drop unnecessary/add missing predvars
+fix_predvars <- function(pv,tt) {
+    if (is.null(pv)) return(NULL)
+    dropvars <- numeric(0)
+    if (length(pv)>1) {
+        for (i in 2:length(pv)) {
+            if (!all(all.vars(pv[[i]]) %in% all.vars(tt))) {
+                dropvars <- c(dropvars,i)
+            }
+        }
+    }
+    if (length(dropvars)>0) {
+        pv <- pv[-dropvars]
+    }
+    if (length(miss_vars <- setdiff(all.vars(tt), all.vars(pv)))>0) {
+        i <- length(pv)
+        for (m in miss_vars) {
+            pv[[i+1]] <- as.symbol(m)
+            i <- i+1
+        }
+    }
+    return(pv)
+}

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -12,6 +12,11 @@
       this information can easily be retrieved by \code{as.data.frame(ranef(.))}.
     }
   }
+  \subsection{BUG FIXES}{
+    \itemize{
+       \item \code{predict} was not handling data-dependent predictors (e.g. \code{poly}, \code{spline}, \code{scale}) correctly
+    }
+  }
 }
 \section{CHANGES IN VERSION 0.2.2}{
   \subsection{NEW FEATURES}{

--- a/glmmTMB/tests/testthat/test-VarCorr.R
+++ b/glmmTMB/tests/testthat/test-VarCorr.R
@@ -10,7 +10,8 @@ context("VarCorr")
 data("Orthodont", package="nlme")
 fm1 <- glmmTMB(distance ~ age + (age|Subject), data = Orthodont)
 fm1C <-   lmer(distance ~ age + (age|Subject), data = Orthodont,
-               REML=FALSE) # to compare
+               REML=FALSE,
+       control=lmerControl(check.conv.grad = .makeCC("warning", tol = 2e-2)))
 gm1 <- glmmTMB(incidence/size ~ period + (1 | herd),
                weights=size,
                data = cbpp, family = binomial)
@@ -41,7 +42,8 @@ data("Pixel", package="nlme")
 complex_form <- pixel ~ day + I(day^2) + (day | Dog) + (1 | Side/Dog)
 expect_warning(fmPix1 <<- glmmTMB(complex_form, data = Pixel),
                "convergence problem")
-fmPix1B <-   lmer(complex_form, data = Pixel)
+fmPix1B <-   lmer(complex_form, data = Pixel,
+      control=lmerControl(check.conv.grad = .makeCC("warning", tol = 5e-3)))
 
 vPix1B <- unlist(lapply(VarCorr(fmPix1B),c))
 vPix1 <- unlist(lapply(VarCorr(fmPix1)[["cond"]],c))

--- a/glmmTMB/tests/testthat/test-predict.R
+++ b/glmmTMB/tests/testthat/test-predict.R
@@ -118,7 +118,8 @@ expect_warning(predict(g0_zi,newdata=dd,zitype="zprob"))
     
 context("complex bases")
 data("sleepstudy",package="lme4")
-
+nd <- data.frame(Days=0,
+                 Subject=factor("309", levels=levels(sleepstudy$Subject)))
 
 test_that("poly", {
     g1 <- glmmTMB(Reaction~poly(Days,3), sleepstudy)
@@ -135,4 +136,20 @@ test_that("scale", {
     g3 <- glmmTMB(Reaction~scale(Days), sleepstudy)
     expect_equal(predict(g3, newdata=data.frame(Days=0)),
                  251.40507651, tolerance=1e-5)
+})
+test_that("poly_RE", {
+    g1 <- glmmTMB(Reaction~(1|Subject) + poly(Days,3), sleepstudy)
+    expect_equal(predict(g1, newdata=nd, allow.new.levels=TRUE),
+                 178.1629812, tolerance=1e-5)
+})
+test_that("splines_RE", {
+    g2 <- glmmTMB(Reaction~(1|Subject) + splines::ns(Days,5), sleepstudy)
+    expect_equal(predict(g2, newdata=nd, allow.new.levels=TRUE),
+                 179.7784754, tolerance=1e-5)
+})
+
+test_that("scale_RE", {
+    g3 <- glmmTMB(Reaction~(1|Subject) + scale(Days), sleepstudy)
+    expect_equal(predict(g3, newdata=nd, allow.new.levels=TRUE),
+                 173.83923026, tolerance=1e-5)
 })

--- a/glmmTMB/tests/testthat/test-predict.R
+++ b/glmmTMB/tests/testthat/test-predict.R
@@ -116,3 +116,23 @@ context("deprecated zitype parameter")
 expect_warning(predict(g0_zi,newdata=dd,zitype="zprob"))
     
     
+context("complex bases")
+data("sleepstudy",package="lme4")
+
+
+test_that("poly", {
+    g1 <- glmmTMB(Reaction~poly(Days,3), sleepstudy)
+    expect_equal(predict(g1, newdata=data.frame(Days=0)),
+                 255.7690496, tolerance=1e-5)
+})
+test_that("splines", {
+    g2 <- glmmTMB(Reaction~splines::ns(Days,5), sleepstudy)
+    expect_equal(predict(g2, newdata=data.frame(Days=0)),257.42672,
+                 tolerance=1e-5)
+})
+
+test_that("scale", {
+    g3 <- glmmTMB(Reaction~scale(Days), sleepstudy)
+    expect_equal(predict(g3, newdata=data.frame(Days=0)),
+                 251.40507651, tolerance=1e-5)
+})

--- a/glmmTMB/tests/testthat/test-reml.R
+++ b/glmmTMB/tests/testthat/test-reml.R
@@ -20,7 +20,8 @@ test_that("REML check against lmer", {
     Orthodont$nsex <- as.numeric(Orthodont$Sex=="Male")
     Orthodont$nsexage <- with(Orthodont, nsex*age)
     fm2.lmer <- lmer(distance ~ age + (age|Subject) + (0+nsex|Subject) +
-                         (0 + nsexage|Subject), data=Orthodont, REML=TRUE)
+                         (0 + nsexage|Subject), data=Orthodont, REML=TRUE,
+          control=lmerControl(check.conv.grad = .makeCC("warning", tol = 5e-3)))
     fm2.glmmTMB <- glmmTMB(distance ~ age + (age|Subject) + (0+nsex|Subject) +
                                (0 + nsexage|Subject), data=Orthodont, REML=TRUE)
     expect_equal( logLik(fm2.lmer) , logLik(fm2.glmmTMB), tolerance=1e-5 )


### PR DESCRIPTION
This is (1) not heavily tested and (2) not as elegant as I'd like (see especially `fix_predvars` in `utils.R` ... using `append()` would make it *slightly* nicer, but it still uses `all.vars()` in  a fairly crude way ... but this seems like an important bug.  Comments and more extensive test cases welcome!