### PR TITLE
Fixing MCMC vignette with workaround for knitr function

### DIFF
--- a/glmmTMB/vignettes/mcmc.rmd
+++ b/glmmTMB/vignettes/mcmc.rmd
@@ -20,8 +20,8 @@ One commonly requested feature is to be able to run a *post hoc* Markov chain Mo
 ```{r knitr_setup, include=FALSE, message=FALSE}
 library(knitr)
 opts_chunk$set(echo = TRUE)
-mcscript <- system.file("vignette_data","mcmc.R",package="glmmTMB")
-read_chunk(mcscript)
+rc <- knitr::read_chunk
+rc(system.file("vignette_data","mcmc.R",package="glmmTMB"))
 ```
 
 Load packages:

--- a/glmmTMB/vignettes/mcmc.rmd
+++ b/glmmTMB/vignettes/mcmc.rmd
@@ -20,7 +20,8 @@ One commonly requested feature is to be able to run a *post hoc* Markov chain Mo
 ```{r knitr_setup, include=FALSE, message=FALSE}
 library(knitr)
 opts_chunk$set(echo = TRUE)
-read_chunk(system.file("vignette_data","mcmc.R",package="glmmTMB"))
+mcscript <- system.file("vignette_data","mcmc.R",package="glmmTMB")
+read_chunk(mcscript)
 ```
 
 Load packages:


### PR DESCRIPTION
- Wrapping `knitr::read_chunk` in order to force this in current R environment

Reference for fix: https://github.com/yihui/knitr/issues/1647