### PR TITLE
Xenial and newer compilers in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: r
+dist: xenial
+
 sudo: false
 r: 
   - release
@@ -9,23 +11,47 @@ latex: true
 r_build_args: '--no-build-vignettes --no-manual'
 r_check_args: '--ignore-vignettes --no-manual'
 
+# Compilation dependencies
+addons:
+  apt:
+    sources:
+      - llvm-toolchain-xenial-7
+    packages:
+      - libgomp1
+      - clang-5.0
+      - root-system-bin
+      - libroot-tree-dev
+      - libroot-tree-treeplayer-dev
+      - libroot-io-dev 
+      - libllvm7 
+      - libstdc++6 
+      - libclang-common-7-dev 
+      - clang-7
+
+
 r_github_packages:
   - jimhester/covr
 
 env:
   matrix:
-    - CXX_OLEVEL=2 CXX=clang++
+    - CXX_OLEVEL=2 CXX=clang++ CC=clang
+  global:
+    - OMP_NUM_THREADS=1
 
 before_install:
   - mkdir -p ~/.R/
   - echo "CXX = `R CMD config CXX`" >> ~/.R/Makevars
-  - echo "CXXFLAGS = `R CMD config CXXFLAGS` -pedantic -g0" >> ~/.R/Makevars
+  - echo "SHLIB_OPENMP_CXXFLAGS= -fopenmp" >> ~/.R/Makevars
+  - echo "CXXFLAGS= -fopenmp `R CMD config CXXFLAGS` -pedantic -g0" >> ~/.R/Makevars
   - export CLANG_EXTRA_ARG=""
-  - if [[ $CXX = "clang++" ]] ;  then export CLANG_EXTRA_ARG=" -Qunused-arguments -fcolor-diagnostics " ; fi
-  - sed -i.bak "s/ g++/ ${CXX}${CLANG_EXTRA_ARG}/" ~/.R/Makevars
+  - if [[ $CXX = "clang++" ]] ;  then export CLANG_EXTRA_ARG=" -fopenmp -Qunused-arguments -fcolor-diagnostics" ; fi
+  - sed -i.bak "s/ g++/ ${CXX} ${CLANG_EXTRA_ARG} ${SHLIB_OPENMP_CXXFLAGS}/" ~/.R/Makevars
   - sed -i.bak "s/O[0-3]/O$CXX_OLEVEL/" ~/.R/Makevars
   - tlmgr install chicago
   - cd glmmTMB
+# Link to OpenMP library for clang (https://github.com/jobovy/extreme-deconvolution/blob/master/.travis.yml)
+  - export LD_LIBRARY_PATH=$(if [[ $CC == "clang" ]]; then echo -n '/usr/local/clang/lib'; fi)
+
 
 script:
   - |
@@ -37,6 +63,5 @@ after_script:
   - echo ${NOT_CRAN}
 
 after_success:
-  - travis_wait 40 tar -C .. -xf $PKG_TARBALL
+  - tar -C .. -xf $PKG_TARBALL
 ##  - travis_wait 40 Rscript -e 'covr::coveralls()'
-


### PR DESCRIPTION
Upgrade Travis to use Ubuntu Xenial along with newer versions of compilers to be able to use OMP properly