### PR TITLE
Downstream methods fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,11 @@ build:
 	$(R) CMD build $(PACKAGE)
 
 check: $(TARBALL)
-	export R_S3_METHOD_LOOKUP_BASEENV_AFTER_GLOBALENV=TRUE
+	export _R_S3_METHOD_LOOKUP_BASEENV_AFTER_GLOBALENV=TRUE
 	$(R) CMD check $(TARBALL)
 
 check-cran: $(TARBALL)
-	export R_S3_METHOD_LOOKUP_BASEENV_AFTER_GLOBALENV=TRUE
+	export _R_S3_METHOD_LOOKUP_BASEENV_AFTER_GLOBALENV=TRUE
 	$(R) CMD check --as-cran $(TARBALL)
 
 ## *NOT* using 'R --vanilla' : then cannot find testthat, TMB, etc they are installed into R's "system" library

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ build:
 	$(R) CMD build $(PACKAGE)
 
 check: $(TARBALL)
+	export R_S3_METHOD_LOOKUP_BASEENV_AFTER_GLOBALENV=TRUE
 	$(R) CMD check $(TARBALL)
 
 check-cran: $(TARBALL)

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ check: $(TARBALL)
 	$(R) CMD check $(TARBALL)
 
 check-cran: $(TARBALL)
+	export R_S3_METHOD_LOOKUP_BASEENV_AFTER_GLOBALENV=TRUE
 	$(R) CMD check --as-cran $(TARBALL)
 
 ## *NOT* using 'R --vanilla' : then cannot find testthat, TMB, etc they are installed into R's "system" library

--- a/glmmTMB/NAMESPACE
+++ b/glmmTMB/NAMESPACE
@@ -35,7 +35,6 @@ S3method(simulate,glmmTMB)
 S3method(summary,glmmTMB)
 S3method(terms,glmmTMB)
 S3method(vcov,glmmTMB)
-export(Effect.glmmTMB)
 export(VarCorr)
 export(addForm)
 export(beta_family)
@@ -72,6 +71,11 @@ if(getRversion() >= "3.6.0") {
      S3method(car::Anova, glmmTMB)
 } else {
   export(Anova.glmmTMB)
+}
+if(getRversion() >= "3.6.0") {
+  S3method(effects::Effect, glmmTMB)
+} else {
+  export(Effect.glmmTMB)
 }
 if(getRversion() >= "3.6.0") {
   S3method(emmeans::emm_basis, glmmTMB)

--- a/glmmTMB/NAMESPACE
+++ b/glmmTMB/NAMESPACE
@@ -35,7 +35,6 @@ S3method(simulate,glmmTMB)
 S3method(summary,glmmTMB)
 S3method(terms,glmmTMB)
 S3method(vcov,glmmTMB)
-export(Anova.glmmTMB)
 export(Effect.glmmTMB)
 export(VarCorr)
 export(addForm)
@@ -43,7 +42,6 @@ export(beta_family)
 export(betabinomial)
 export(compois)
 export(dropHead)
-export(emm_basis.glmmTMB)
 export(extractForm)
 export(fixef)
 export(genpois)
@@ -61,7 +59,6 @@ export(noSpecials)
 export(numFactor)
 export(parseNumLevels)
 export(ranef)
-export(recover_data.glmmTMB)
 export(sigma)
 export(splitForm)
 export(tmbroot)
@@ -71,6 +68,21 @@ export(truncated_nbinom1)
 export(truncated_nbinom2)
 export(truncated_poisson)
 export(tweedie)
+if(getRversion() >= "3.6.0") {
+     S3method(car::Anova, glmmTMB)
+} else {
+  export(Anova.glmmTMB)
+}
+if(getRversion() >= "3.6.0") {
+  S3method(emmeans::emm_basis, glmmTMB)
+} else {
+  export(emm_basis.glmmTMB)
+}
+if(getRversion() >= "3.6.0") {
+  S3method(emmeans::recover_data, glmmTMB)
+} else {
+  export(recover_data.glmmTMB)
+}
 if(getRversion()>='3.3.0') importFrom(stats, sigma) else importFrom(lme4,sigma)
 importFrom(Matrix,Cholesky)
 importFrom(Matrix,Diagonal)

--- a/glmmTMB/R/Anova.R
+++ b/glmmTMB/R/Anova.R
@@ -44,7 +44,12 @@ has.intercept.glmmTMB <- function (model, component="cond", ...) {
 }
 
 ##' @rdname downstream_methods
-##' @export Anova.glmmTMB
+##' @rawNamespace if(getRversion() >= "3.6.0") {
+##'      S3method(car::Anova, glmmTMB)
+##' } else {
+##'   export(Anova.glmmTMB)
+##' }
+
 ##' @param vcov. variance-covariance matrix (usually extracted automatically)
 ##' @param test.statistic unused: only valid choice is "Chisq" (i.e., Wald chi-squared test)
 ##' @param singular.ok OK to do ANOVA with singular models (unused) ?

--- a/glmmTMB/R/effects.R
+++ b/glmmTMB/R/effects.R
@@ -4,7 +4,12 @@
 ##' @param focal.predictors a character vector of one or more predictors in the
 ##'  model in any order.
 
-##' @export Effect.glmmTMB
+##'
+##' @rawNamespace if(getRversion() >= "3.6.0") {
+##'   S3method(effects::Effect, glmmTMB)
+##' } else {
+##'   export(Effect.glmmTMB)
+##' }
 Effect.glmmTMB <- function (focal.predictors, mod, ...) {
     fam <- family(mod)
     ## code to make the 'truncated_*' families work

--- a/glmmTMB/R/emmeans.R
+++ b/glmmTMB/R/emmeans.R
@@ -60,7 +60,11 @@
 ## }
 
 #' @importFrom stats delete.response
-#' @export recover_data.glmmTMB
+#' @rawNamespace if(getRversion() >= "3.6.0") {
+#'   S3method(emmeans::recover_data, glmmTMB)
+#' } else {
+#'   export(recover_data.glmmTMB)
+#' }
 recover_data.glmmTMB <- function(object, ...) {
     fcall <- getCall(object)
     if (!requireNamespace("emmeans"))
@@ -93,7 +97,11 @@ recover_data.glmmTMB <- function(object, ...) {
 #' @aliases downstream_methods
 #' @param component which component of the model to compute emmeans for (conditional ("cond"), zero-inflation ("zi"), or dispersion ("disp"))
 
-#' @export emm_basis.glmmTMB
+#' @rawNamespace if(getRversion() >= "3.6.0") {
+#'   S3method(emmeans::emm_basis, glmmTMB)
+#' } else {
+#'   export(emm_basis.glmmTMB)
+#' }
 emm_basis.glmmTMB <- function (object, trms, xlev, grid, component="cond", ...) {
     if (component != "cond") warning("only tested for conditional component")
     V <- as.matrix(vcov(object)[[component]])


### PR DESCRIPTION
attempt to fix method exports as specified [here](https://stat.ethz.ch/pipermail/r-package-devel/2019q1/003331.html).  So far have been unable to reproduce the error in the unfixed (master) version even with `_R_S3_METHOD_LOOKUP_BASEENV_AFTER_GLOBALENV_=TRUE` ...