### PR TITLE
add 'start' parameter

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -185,7 +185,7 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
     
   for (p in names(start)) {
       if ((Lp <- length(parameters[[p]])) !=  (Ls <- length(start[[p]]))) {
-          stop(sprintf("parameter vector length mismatch: length(%s) is %d, should be %d", p, Lp, Ls))
+          stop(sprintf("parameter vector length mismatch: length(%s) is %d, should be %d", Lp, p, Ls))
       }
       parameters[[p]] <- start[[p]]
   }

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -184,8 +184,13 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
                      ))
     
   for (p in names(start)) {
+      if (!(p %in% names(parameters))) {
+          stop(sprintf("unrecognized vector '%s' in %s",p,sQuote("start")),
+               call. = FALSE)
+      }
       if ((Lp <- length(parameters[[p]])) !=  (Ls <- length(start[[p]]))) {
-          stop(sprintf("parameter vector length mismatch: length(%s) is %d, should be %d", Lp, p, Ls))
+          stop(sprintf("parameter vector length mismatch: in %s, length(%s)==%d, should be %d", sQuote("start"), p, Ls, Lp),
+               call. = FALSE)
       }
       parameters[[p]] <- start[[p]]
   }

--- a/glmmTMB/man/glmmTMB.Rd
+++ b/glmmTMB/man/glmmTMB.Rd
@@ -8,7 +8,7 @@ glmmTMB(formula, data = NULL, family = gaussian(), ziformula = ~0,
   dispformula = ~1, weights = NULL, offset = NULL,
   contrasts = NULL, na.action = na.fail, se = TRUE,
   verbose = FALSE, doFit = TRUE, control = glmmTMBControl(),
-  REML = FALSE)
+  REML = FALSE, start = NULL)
 }
 \arguments{
 \item{formula}{combined fixed and random effects formula, following lme4
@@ -50,6 +50,14 @@ without fitting the model}
 \item{control}{control parameters; see \code{\link{glmmTMBControl}}.}
 
 \item{REML}{Logical; Use REML estimation rather than maximum likelihood.}
+
+\item{start}{starting values, expressed as a list with possible components
+\code{beta}, \code{betazi}, \code{betad} (fixed-effect parameters for
+conditional, zero-inflation, dispersion models); \code{b}, \code{bzi}
+(conditional modes for conditional and zero-inflation models);
+\code{theta}, \code{thetazi} (random-effect parameters, on the
+standard deviation/Cholesky scale, for conditional and z-i models);
+\code{thetaf} (extra family parameters, e.g. shape for Tweedie models)}
 }
 \description{
 Fit models with TMB

--- a/glmmTMB/man/mkTMBStruc.Rd
+++ b/glmmTMB/man/mkTMBStruc.Rd
@@ -7,14 +7,26 @@
 mkTMBStruc(formula, ziformula, dispformula, combForm, mf, fr, yobs,
   respCol, weights, contrasts, size = NULL, family, se = NULL,
   call = NULL, verbose = NULL, ziPredictCode = "corrected",
-  doPredict = 0, whichPredict = integer(0), REML = FALSE)
+  doPredict = 0, whichPredict = integer(0), REML = FALSE,
+  start = NULL)
 }
 \arguments{
-\item{formula}{conditional formula}
+\item{formula}{combined fixed and random effects formula, following lme4
+syntax}
 
-\item{ziformula}{zero-inflation formula}
+\item{ziformula}{a \emph{one-sided} (i.e., no response variable) formula for
+    zero-inflation combining fixed and random effects:
+the default \code{~0} specifies no zero-inflation.
+Specifying \code{~.} sets the zero-inflation
+formula identical to the right-hand side of \code{formula} (i.e., the conditional effects formula); terms can also be added or subtracted. \strong{When using \code{~.} as the zero-inflation formula in models where the conditional effects formula contains an offset term, the offset term will automatically be dropped}.
+The zero-inflation model uses a logit link.}
 
-\item{dispformula}{dispersion formula}
+\item{dispformula}{a \emph{one-sided} formula for dispersion containing only fixed effects: the
+default \code{~1} specifies the standard dispersion given any family.
+The argument is ignored for families that do not have a dispersion parameter.
+For an explanation of the dispersion parameter for each family, see (\code{\link{sigma}}).
+The dispersion model uses a log link. 
+In Gaussian mixed models, \code{dispformula=~0} fixes the parameter to be 0, forcing variance into the random effects.}
 
 \item{combForm}{combined formula}
 
@@ -26,9 +38,9 @@ mkTMBStruc(formula, ziformula, dispformula, combForm, mf, fr, yobs,
 
 \item{respCol}{response column}
 
-\item{weights}{weights}
+\item{weights}{weights, as in \code{glm}. Not automatically scaled to have sum 1.}
 
-\item{contrasts}{contrasts}
+\item{contrasts}{an optional list, e.g. \code{list(fac1="contr.sum")}. See the \code{contrasts.arg} of \code{\link{model.matrix.default}}.}
 
 \item{size}{number of trials in binomial and betabinomial families}
 
@@ -47,6 +59,14 @@ mkTMBStruc(formula, ziformula, dispformula, combForm, mf, fr, yobs,
 \item{whichPredict}{which observations in model frame represent predictions}
 
 \item{REML}{Logical; Use REML estimation rather than maximum likelihood.}
+
+\item{start}{starting values, expressed as a list with possible components
+\code{beta}, \code{betazi}, \code{betad} (fixed-effect parameters for
+conditional, zero-inflation, dispersion models); \code{b}, \code{bzi}
+(conditional modes for conditional and zero-inflation models);
+\code{theta}, \code{thetazi} (random-effect parameters, on the
+standard deviation/Cholesky scale, for conditional and z-i models);
+\code{thetaf} (extra family parameters, e.g. shape for Tweedie models)}
 
 \item{zioffset}{offset for zero-inflated model}
 

--- a/glmmTMB/tests/testthat/test-start.R
+++ b/glmmTMB/tests/testthat/test-start.R
@@ -1,0 +1,15 @@
+stopifnot(require("testthat"),
+          require("glmmTMB"))
+
+data(sleepstudy, cbpp,
+     package = "lme4")
+
+test_that("error messages for user-spec start", {
+    expect_error(
+        glmmTMB(Reaction~Days+(Days|Subject), sleepstudy,
+                start=list(beta=c(2))),
+        "parameter vector length mismatch.*length\\(beta\\)==1, should be 2")
+    expect_error(glmmTMB(Reaction~Days+(Days|Subject), sleepstudy,
+                         start=list(junk=5)),
+                 "unrecognized vector 'junk'")
+})


### PR DESCRIPTION
This allows the user to specify starting values.

I think it's fairly harmless; the only open question I can think of is whether we'd rather make `start` an additional top-level parameter to `glmmTMB`, or whether it should instead be included as part of `glmmTMBControl`  (`lme4` has it as a top-level parameter).