### PR TITLE
Zi beta

### DIFF
--- a/glmmTMB/R/family.R
+++ b/glmmTMB/R/family.R
@@ -315,3 +315,24 @@ getCapabilities <- function(what="all",check=FALSE) {
         return(family_OK)
     }
 }
+
+Gamma <- function(link="inverse") {
+    g <- stats::Gamma(link=link)
+    ## stats::Gamma does clever deparsing stuff ... need to work around it ...
+    if (is.function(link)) {
+        g$link <- deparse(substitute(link))
+    } else g$link <- link
+    ## modify initialization to allow zero values in zero-inflated cases
+    g$initialize <- expression({
+        if (exists("ziformula") && !ident(ziformula, ~0)) {
+            if (any(y < 0)) stop("negative values not allowed for the 'Gamma' family with zero-inflation")
+            } else {
+                if (any(y <= 0)) stop("non-positive values not allowed for the 'Gamma' family")
+            }
+            n <- rep.int(1, nobs)
+            mustart <- y
+    })
+
+   return(g)
+}
+

--- a/glmmTMB/R/family.R
+++ b/glmmTMB/R/family.R
@@ -225,8 +225,14 @@ beta_family <- function(link="logit") {
     r <- list(family="beta",
               variance=function(mu) { mu*(1-mu) },
               initialize=expression({
-                  if (any(y <= 0 | y >= 1)) 
-                      stop("y values must be 0 < y < 1")
+                  if (exists("ziformula") && !ident(ziformula, ~0)) {
+                      if (any(y < 0 | y >= 1)) {
+                          stop("y values must be 0 <= y < 1")
+                      }
+                  } else {
+                      if (any(y <= 0 | y >= 1)) 
+                          stop("y values must be 0 < y < 1")
+                  }
                   mustart <- y
               }))
     return(make_family(r,link))

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -720,6 +720,7 @@ glmmTMB <- function (
     ##  AND (inverse-link  & any(y==0)) OR (log-link & any(y<=0))
     ##  and then only to check whether it's NULL or not ...
     etastart <- mustart <- NULL
+
     if (!is.null(family$initialize)) {
         local(eval(family$initialize))  ## 'local' so it checks but doesn't modify 'y' and 'weights'
     }

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -30,13 +30,15 @@ cNames <- list(cond = "Conditional model",
                zi = "Zero-inflation model",
                disp = "Dispersion model")
 
-## FIXME: this is a bit ugly. On the other hand, a single-parameter
-## dispersion model without a (... ?)
+## check identity without worrying about environments etc.
+ident <- function(x,target) isTRUE(all.equal(x,target))
 
 formComp <- function(object,type="dispformula",target) {
-    isTRUE(all.equal(object$modelInfo$allForm[[type]],target)) ||
-        isTRUE(all.equal(object$call[[type]],target))
+    ident(object$modelInfo$allForm[[type]],target) ||
+        ident(object$call[[type]],target)
 }
+## FIXME: this is a bit ugly. On the other hand, a single-parameter
+## dispersion model without a (... ?)
 
 trivialDisp <- function(object) {
     formComp(object,"dispformula",~1)
@@ -51,7 +53,6 @@ trivialFixef <- function(xnm,nm) {
         (nm %in% c('d','disp') && identical(xnm,'(Intercept)'))
     ## FIXME: inconsistent tagging; should change 'Xd' to 'Xdisp'?
 }
-
 
 ##' @method print fixef.glmmTMB
 ##' @export

--- a/glmmTMB/tests/testthat/test-zi.R
+++ b/glmmTMB/tests/testthat/test-zi.R
@@ -32,6 +32,10 @@ test_that("zi", {
     expect_equal(fixef(owls_nb2),fixef(owls_nb3))
 })
 
-suppressWarnings(RNGversion("3.5.1"))
-dd <- data.frame(y=c(rbeta(100,shape1=2,shape2=1),rep(0,10)))
-glmmTMB(y~1, data=dd, family=beta_family, zi=~1)
+test_that("zi beta", {
+    suppressWarnings(RNGversion("3.5.1"))
+    dd <- data.frame(y=c(rbeta(100,shape1=2,shape2=1),rep(0,10)))
+    m1 <- glmmTMB(y~1, data=dd, family=beta_family, zi=~1)
+    expect_equal(unname(plogis(fixef(m1)[["zi"]])),1/11)
+    expect_equal(unname(fixef(m1)[["cond"]]),0.677291,tolerance=1e-5)
+})

--- a/glmmTMB/tests/testthat/test-zi.R
+++ b/glmmTMB/tests/testthat/test-zi.R
@@ -32,3 +32,6 @@ test_that("zi", {
     expect_equal(fixef(owls_nb2),fixef(owls_nb3))
 })
 
+suppressWarnings(RNGversion("3.5.1"))
+dd <- data.frame(y=c(rbeta(100,shape1=2,shape2=1),rep(0,10)))
+glmmTMB(y~1, data=dd, family=beta_family, zi=~1)

--- a/glmmTMB/tests/testthat/test-zi.R
+++ b/glmmTMB/tests/testthat/test-zi.R
@@ -34,8 +34,9 @@ test_that("zi", {
 
 test_that("zi beta", {
     suppressWarnings(RNGversion("3.5.1"))
+    set.seed(101)
     dd <- data.frame(y=c(rbeta(100,shape1=2,shape2=1),rep(0,10)))
     m1 <- glmmTMB(y~1, data=dd, family=beta_family, zi=~1)
     expect_equal(unname(plogis(fixef(m1)[["zi"]])),1/11)
-    expect_equal(unname(fixef(m1)[["cond"]]), 0.704939, tolerance=1e-5)
+    expect_equal(unname(fixef(m1)[["cond"]]), 0.6211636, tolerance=1e-5)
 })

--- a/glmmTMB/tests/testthat/test-zi.R
+++ b/glmmTMB/tests/testthat/test-zi.R
@@ -37,5 +37,5 @@ test_that("zi beta", {
     dd <- data.frame(y=c(rbeta(100,shape1=2,shape2=1),rep(0,10)))
     m1 <- glmmTMB(y~1, data=dd, family=beta_family, zi=~1)
     expect_equal(unname(plogis(fixef(m1)[["zi"]])),1/11)
-    expect_equal(unname(fixef(m1)[["cond"]]),0.677291,tolerance=1e-5)
+    expect_equal(unname(fixef(m1)[["cond"]]), 0.704939, tolerance=1e-5)
 })

--- a/glmmTMB/tests/testthat/test-zi.R
+++ b/glmmTMB/tests/testthat/test-zi.R
@@ -35,8 +35,16 @@ test_that("zi", {
 test_that("zi beta", {
     suppressWarnings(RNGversion("3.5.1"))
     set.seed(101)
-    dd <- data.frame(y=c(rbeta(100,shape1=2,shape2=1),rep(0,10)))
-    m1 <- glmmTMB(y~1, data=dd, family=beta_family, zi=~1)
+    dd <- data.frame(yb=c(rbeta(100,shape1=2,shape2=1),rep(0,10)),
+                     yg=c(rgamma(100,shape=1.5,rate=1),rep(0,10)))
+    expect_error(glmmTMB(yb~1, data=dd, family=beta_family),
+                 "y values must be")
+    m1 <- glmmTMB(yb~1, data=dd, family=beta_family, zi=~1)
     expect_equal(unname(plogis(fixef(m1)[["zi"]])),1/11)
     expect_equal(unname(fixef(m1)[["cond"]]), 0.6211636, tolerance=1e-5)
+    expect_error(glmmTMB(yg~1, data=dd, family=Gamma),
+                 "non-positive values not allowed")
+    m2 <- glmmTMB(yg~1, data=dd, family=Gamma(link="log"), zi=~1)
+    expect_equal(unname(plogis(fixef(m2)[["zi"]])),1/11)
+    expect_equal(unname(fixef(m2)[["cond"]]), 0.3995267, tolerance=1e-5)
 })


### PR DESCRIPTION
this is a preliminary stab at allowing zero-inflation for otherwise-positive (Gamma, beta) response models.  Right now it seems to work OK in a simple beta example.  To make it work for Gamma we will have to work around the $initialize() component of the standard Gamma model, which fails unless 0<y<1. (this wasn't too hard for beta because we are defining our own beta_family()).  Probably the easiest thing to do is to define a new Gamma_zi family which relaxes the checks to 0<=y<1 ...  We *could* mask stats::Gamma, but that always seems questionable (in this case it might be defensible because we're making a very small change -- it should be completely backward compatible).