### PR TITLE
pop-level prediction

### DIFF
--- a/glmmTMB/R/predict.R
+++ b/glmmTMB/R/predict.R
@@ -53,6 +53,7 @@ assertIdenticalModels <- function(data.tmb1, data.tmb0, allow.new.levels=FALSE)
 ##' prediction
 ##' @param object a \code{glmmTMB} object
 ##' @param newdata new data for prediction
+##' @param newparams new parameters for prediction
 ##' @param se.fit return the standard errors of the predicted values?
 ##' @param zitype deprecated: formerly used to specify type of zero-inflation probability. Now synonymous with \code{type}
 ##' @param type Denoting \eqn{mu} as the mean of the conditional distribution and
@@ -74,7 +75,7 @@ assertIdenticalModels <- function(data.tmb1, data.tmb0, allow.new.levels=FALSE)
 ##' the default (\code{na.pass}) is to predict \code{NA}
 ##' @param debug (logical) return the \code{TMBStruc} object that will be
 ##' used internally for debugging?
-##' @param re.form (not yet implemented: see Details for population-level predictions) (formula, \code{NULL}, or \code{NA}) specify which random effects to condition on when predicting. 
+##' @param re.form \code{NULL} to specify individual-level predictions; \code{~0} or \code{NA} to specify population-level predictions (i.e., setting all random effects to zero)
 ##' @param allow.new.levels allow previously unobserved levels in random-effects variables? see details.
 ##' @param \dots unused - for method compatibility
 ##' @details
@@ -102,8 +103,9 @@ assertIdenticalModels <- function(data.tmb1, data.tmb0, allow.new.levels=FALSE)
 ##' @importFrom stats optimHess model.frame na.fail na.pass napredict
 ##' @export
 predict.glmmTMB <- function(object,newdata=NULL,
+                            newparams=NULL,
                             se.fit=FALSE,
-                            re.form, allow.new.levels=FALSE,
+                            re.form=NULL, allow.new.levels=FALSE,
                             type = c("link", "response",
                                      "conditional","zprob","zlink"),
                             zitype = NULL,
@@ -118,8 +120,14 @@ predict.glmmTMB <- function(object,newdata=NULL,
      type <- zitype
   }
   type <- match.arg(type)
-  if (!missing(re.form)) stop("re.form not yet implemented")
-  ##if (allow.new.levels) stop("allow.new.levels not yet implemented")
+  ## FIXME: better test? () around re.form==~0 are *necessary*
+  ## could steal isRE from lme4 predict.R ...
+  pop_pred <- (!is.null(re.form) && ((re.form==~0) ||
+                                       identical(re.form,NA)))
+  if (!(is.null(re.form) || pop_pred)) {
+      stop("re.form must equal NULL, NA, or ~0")
+  }
+
   mc <- mf <- object$call
   ## FIXME: DRY so much
   ## now work on evaluating model frame
@@ -219,7 +227,7 @@ predict.glmmTMB <- function(object,newdata=NULL,
   assertIdenticalModels(TMBStruc$data.tmb,
                         object$obj$env$data, allow.new.levels)
                         
-  ## Check that the neccessary predictor variables are finite (not NA nor NaN)
+  ## Check that the necessary predictor variables are finite (not NA nor NaN)
   if(se.fit) {
     with(TMBStruc$data.tmb, if(any(!is.finite(X)) |
                              any(!is.finite(Z@x)) |
@@ -239,7 +247,13 @@ predict.glmmTMB <- function(object,newdata=NULL,
                            silent = TRUE,
                            DLL = "glmmTMB"))
 
-  oldPar <- object$fit$par
+  origPar <- oldPar <- object$fit$par
+    
+  on.exit(newObj$fn(origPar))
+  if (!is.null(newparams)) oldPar <- newparams    
+  if (pop_pred) {
+      oldPar[names(oldPar)=="theta"] <- (-100)
+  }    
   newObj$fn(oldPar)  ## call once to update internal structures
   lp <- newObj$env$last.par
 

--- a/glmmTMB/man/predict.glmmTMB.Rd
+++ b/glmmTMB/man/predict.glmmTMB.Rd
@@ -4,19 +4,21 @@
 \alias{predict.glmmTMB}
 \title{prediction}
 \usage{
-\method{predict}{glmmTMB}(object, newdata = NULL, se.fit = FALSE,
-  re.form, allow.new.levels = FALSE, type = c("link", "response",
-  "conditional", "zprob", "zlink"), zitype = NULL, na.action = na.pass,
-  debug = FALSE, ...)
+\method{predict}{glmmTMB}(object, newdata = NULL, newparams = NULL,
+  se.fit = FALSE, re.form = NULL, allow.new.levels = FALSE,
+  type = c("link", "response", "conditional", "zprob", "zlink"),
+  zitype = NULL, na.action = na.pass, debug = FALSE, ...)
 }
 \arguments{
 \item{object}{a \code{glmmTMB} object}
 
 \item{newdata}{new data for prediction}
 
+\item{newparams}{new parameters for prediction}
+
 \item{se.fit}{return the standard errors of the predicted values?}
 
-\item{re.form}{(not yet implemented: see Details for population-level predictions) (formula, \code{NULL}, or \code{NA}) specify which random effects to condition on when predicting.}
+\item{re.form}{\code{NULL} to specify individual-level predictions; \code{~0} or \code{NA} to specify population-level predictions (i.e., setting all random effects to zero)}
 
 \item{allow.new.levels}{allow previously unobserved levels in random-effects variables? see details.}
 

--- a/glmmTMB/tests/testthat/test-predict.R
+++ b/glmmTMB/tests/testthat/test-predict.R
@@ -26,6 +26,15 @@ test_that("manual prediction of pop level pred", {
                  fixef(g0)$cond[1] + fixef(g0)$cond[2] * nd$Days , tol=1e-10)
 })
 
+test_that("population-level prediction", {
+    prnd <- predict(g0)
+    expect_equal(length(unique(prnd)),180)
+    prnd2 <- predict(g0, re.form=~0)
+    prnd3 <- predict(g0, re.form=NA)
+    expect_equal(prnd2,prnd3)
+    expect_equal(length(unique(prnd2)),10)
+})
+
 context("Catch invalid predictions")
 
 test_that("new levels of fixed effect factor", {

--- a/glmmTMB/tests/testthat/test-predict.R
+++ b/glmmTMB/tests/testthat/test-predict.R
@@ -33,6 +33,9 @@ test_that("population-level prediction", {
     prnd3 <- predict(g0, re.form=NA)
     expect_equal(prnd2,prnd3)
     expect_equal(length(unique(prnd2)),10)
+    ## make sure we haven't messed up any internal structures ...
+    prnd4 <- predict(g0)
+    expect_equal(prnd, prnd4)
 })
 
 context("Catch invalid predictions")
@@ -58,9 +61,12 @@ test_that("new levels in AR1 (OK)", {
 
 context("Predict two-column response case")
 
-fm <- glmmTMB( cbind(count,4) ~ mined, family=betabinomial, data=Salamanders)
-expect_equal(predict(fm, type="response"),
-             c(0.05469247, 0.29269818)[Salamanders$mined] )
+test_that("two-column response", {
+    fm <- glmmTMB( cbind(count,4) ~ mined, family=betabinomial,
+                  data=Salamanders)
+    expect_equal(predict(fm, type="response"),
+                 c(0.05469247, 0.29269818)[Salamanders$mined] )
+})
 
 context("Prediction with dispformula=~0")
 y <- 1:10


### PR DESCRIPTION
This could certainly be extended to try to allow a full `re.form` specification (i.e., use particular REs and ignore others), but to do that we would need a robust way to map from a RE formula to a vector specifying which `theta` values to map to -100 (or whatever).