### PR TITLE
address #529 ...

### DIFF
--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -1239,6 +1239,8 @@ refit.glmmTMB <- function(object, newresp, ...) {
           if (is.matrix(newresp)) newresp <- newresp[,1]
           newdata[[deparse(fresp)]] <- newresp
       }
+  } else {
+      newdata[[deparse(fresp)]] <- newresp
   }
   cc$data <- quote(newdata)
   return(eval(cc))

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -1235,9 +1235,11 @@ refit.glmmTMB <- function(object, newresp, ...) {
           } else {
               stop("can't handle this data format, sorry ...")
           }
+      } else {
+          if (is.matrix(newresp)) newresp <- newresp[,1]
+          newdata[[deparse(fresp)]] <- newresp
       }
-  } else newdata[[deparse(fresp)]] <- newresp
-      
+  }
   cc$data <- quote(newdata)
   return(eval(cc))
 }

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -25,7 +25,10 @@
       \item \code{Anova} now respects the \code{component} argument (GH
       #494, from @eds-slim)
       \item \code{predict} now works when contrasts are set on factors
-  in original data (GH #439, from @cvoeten)
+      in original data (GH #439, from @cvoeten)
+      \item \code{bootMer} now works with models with Bernoulli
+      responses (even though \code{simulate()} returns a two-column
+      matrix in this case) (GH #529, @frousseu)
    }
   } % bug fixes
   \subsection{USER-VISIBLE CHANGES}{

--- a/glmmTMB/tests/testthat/test-bootMer.R
+++ b/glmmTMB/tests/testthat/test-bootMer.R
@@ -4,10 +4,23 @@ stopifnot(require("testthat"),
 
 context("bootMer")
 
-test_that("bootMer works for Bernoulli responses", {
-    fun <- function(x) predict(x)[1]
+fun <- function(x) predict(x)[1]
+
+test_that("Bernoulli responses", {
     Salamanders$pres <- as.numeric(Salamanders$count>0)
     m <- glmmTMB(pres ~ mined +(1|site), family=binomial, data=Salamanders)
     b <- lme4::bootMer(m, fun, nsim=2, seed=101)
     expect_true(var(c(b$t))>0)
+    expect_equal(suppressWarnings(c(confint(b))),
+                 c(-1.579923,-1.250725),tolerance=1e-5)
+})
+
+test_that("Bernoulli responses", {
+    m <- glmmTMB(count ~ mined + (1|site), family=poisson, data=Salamanders)
+    ss1 <- simulate(m,nsim=2,seed=101)
+    b <- bootMer(m, fun, nsim=2, seed=101)
+    expect_true(var(c(b$t))>0)
+    expect_equal(suppressWarnings(c(confint(b))),
+                 c(-0.7261239,-0.6921794),
+                 tolerance=1e-5)
 })

--- a/glmmTMB/tests/testthat/test-bootMer.R
+++ b/glmmTMB/tests/testthat/test-bootMer.R
@@ -1,0 +1,13 @@
+stopifnot(require("testthat"),
+          require("glmmTMB"),
+          require("lme4"))
+
+context("bootMer")
+
+test_that("bootMer works for Bernoulli responses", {
+    fun <- function(x) predict(x)[1]
+    Salamanders$pres <- as.numeric(Salamanders$count>0)
+    m <- glmmTMB(pres ~ mined +(1|site), family=binomial, data=Salamanders)
+    b <- lme4::bootMer(m, fun, nsim=2, seed=101)
+    expect_true(var(c(b$t))>0)
+})


### PR DESCRIPTION
I know we talked about this already, but not really sure why `simulate()` is returning a two-column matrix when the original data were Bernoulli (i.e., 0/1 values in a single column). Despite the previous NEWS entry, it is *not* true that base R `simulate()` always returns a two-column matrix for binomial models (see below).

Nevertheless, the new code is robust against this option (if the original predictor was a single column *and* no weights were specified, and the new response variable is a two-column matrix, it takes the first column only ...)

We could conceivably add checking code to make sure that all columns sum to 1 (if not, something weird is happening ...)



```
## Bernoulli
dd <- data.frame(y=c(1,0,1,0,0,1))
g <- glm(y~1, family=binomial, data=dd)
str(simulate(g))
## two-column
g2 <- glm(cbind(y,1-y)~1, family=binomial, data=dd)
str(simulate(g2))
```