### PR TITLE
Correct URL to point to GitHub repo

### DIFF
--- a/glmmTMB/DESCRIPTION
+++ b/glmmTMB/DESCRIPTION
@@ -69,7 +69,7 @@ Suggests:
     huxtable
 SystemRequirements: GNU make
 VignetteBuilder: knitr
-URL: https://github.com/glmmTMB
+URL: https://github.com/glmmTMB/glmmTMB
 LazyData: TRUE
 BugReports: https://github.com/glmmTMB/glmmTMB/issues
 RoxygenNote: 7.0.2


### PR DESCRIPTION
Hi glmmTMB maintainers 👋 ,
The URL in the `DESCRIPTION` file points to the glmmTMB account and not the package repo.
