### PR TITLE
update null-matrix args for Matrix update

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -147,8 +147,9 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
 
   denseXval <- function(component,lst) if (sparseX[[component]]) matrix(nrow=0,ncol=0) else lst$X
   ## need a 'dgTMatrix' (double, general, Triplet representation)
-  sparseXval <- function(component,lst)
-    { if (sparseX[[component]]) lst$X else Matrix::sparseMatrix(dims=c(0,0),i=integer(0),j=integer(0),x=numeric(0),giveCsparse=FALSE) }
+  sparseXval <- function(component,lst) {
+     if (sparseX[[component]]) lst$X else nullSparseMatrix()
+  }
 
   data.tmb <- namedList(
     X = denseXval("cond",condList),

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -714,3 +714,16 @@ pnbinom1 <- function(q, mu, phi, ...) {
 qnbinom1 <- function(p, mu, phi, log=FALSE) {
     pnbinom(p, mu=mu, size=mu/phi, ...)
 }
+
+nullSparseMatrix <- function() {
+    argList <- list(
+        dims=c(0,0),
+        i=integer(0),
+        j=integer(0),
+        x=numeric(0))
+    if (packageVersion("Matrix")<"1.3.0") {
+        do.call(Matrix::sparseMatrix, c(argList, list(giveCsparse=FALSE)))
+    } else {
+        do.call(Matrix::sparseMatrix, c(argList, list(repr="T")))
+    }
+}


### PR DESCRIPTION
`Matrix::sparseMatrix` args will be changing in an upcoming version, leading to lots of warnings (`giveCSparse` is deprecated in favour of `repr="T"`). This version (which preserves back-compatibility) may be overkill, we could also wait until the new version is out and impose a package version dependency ...