### PR TITLE
correct error structure for fast=TRUE + re.form=NA

### DIFF
--- a/glmmTMB/R/predict.R
+++ b/glmmTMB/R/predict.R
@@ -156,16 +156,14 @@ predict.glmmTMB <- function(object,
   if (!is.null(newparams)) oldPar <- newparams
 
   new_stuff <- !is.null(newdata) || !is.null(newparams) || pop_pred
-  if (!is.null(fast)) {
-     if (new_stuff) {
-         stop("fast=TRUE is not compatible with newdata/newparams/population-level prediction")
-     }
-   } else {
-     fast <- !new_stuff
-   }
+  if (isTRUE(fast) && new_stuff) {
+    stop("fast=TRUE is not compatible with newdata/newparams/population-level prediction")
+  }
 
-   if (fast) {
-    ee <- environment(object$obj$fn)       
+  if (is.null(fast)) fast <- !new_stuff
+
+  if (fast) {
+    ee <- environment(object$obj$fn)
     lp <- ee$last.par.best                 ## used in $report() call below
     dd <- ee$data         ## data object
     orig_vals <- dd[c("whichPredict","doPredict","ziPredictCode")]

--- a/glmmTMB/tests/testthat/test-predict.R
+++ b/glmmTMB/tests/testthat/test-predict.R
@@ -292,3 +292,10 @@ test_that("fast prediction", {
     ## handling NAs etc.
     expect_equal(pp_ex, predict(fm2_ex, fast=FALSE))
 })
+
+test_that("fast prediction not allowed with NA (correct errors)", {
+  expect_error(predict(fm2, re.form=NA, fast=TRUE),
+               "fast=TRUE is not compatible")
+  expect_equal(predict(fm2, re.form=NA, fast=FALSE),
+               predict(fm2, re.form=NA, fast=NULL))
+})


### PR DESCRIPTION
I discovered a fairly trivial/unimportant logic error (`predict(..., re.form=NA, fast=FALSE)` should be allowed but isn't)