### PR TITLE
Make hessian symmetric

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -1380,6 +1380,7 @@ fitTMB <- function(TMBStruc) {
               par <- par[-rr]
           }
           h <- numDeriv::jacobian(obj$gr, par)
+          h <- .5 * (h + t(h))
           eigs <- eigen(h)
           ev <- e_complex_check(eigs$values)
           if (min(ev)>.Machine$double.eps) {

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -1241,7 +1241,7 @@ fitTMB <- function(TMBStruc) {
             }
         },
         TMB::openmp(NULL)
-    )    
+    )
     ## Only proceed farther if OpenMP *is* supported ...
     if (n_orig>0) {
         TMB::openmp(n = control$parallel)
@@ -1380,8 +1380,10 @@ fitTMB <- function(TMBStruc) {
               par <- par[-rr]
           }
           h <- numDeriv::jacobian(obj$gr, par)
-          h <- .5 * (h + t(h))
+          h <- .5 * (h + t(h))  ## symmetrize
           eigs <- eigen(h)
+          ## complex-values check should be unnecessary because we
+          ## now symmetrize the hessian, but who knows ... ?
           ev <- e_complex_check(eigs$values)
           if (min(ev)>.Machine$double.eps) {
               ## apparently fit is OK after all ...


### PR DESCRIPTION
I see `make test` failing because of (new?) complex eigenvalue check. Note that `Jacobian(gr, par)` will result in un-symmetric result 'at random' so `e_complex_check()` is sort of pointless IMO.

✖ |  30 1     | fitting exotic families [12.4 s]                                                                                                                                                            
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Error (test-families.R:199:5): dbetabinom
Error: detected complex eigenvalues of covariance matrix (max(abs(Im))=1.13473e-10: try se=FALSE?
Backtrace:
 1. base::suppressWarnings(...) test-families.R:199:4
 3. glmmTMB::glmmTMB(...)
 4. glmmTMB::fitTMB(TMBStruc) /zhome/8a/0/39821/glmmTMB/glmmTMB/R/glmmTMB.R:1085:4
 5. glmmTMB:::e_complex_check(eigs$values) /zhome/8a/0/39821/glmmTMB/glmmTMB/R/glmmTMB.R:1384:10
