### PR TITLE
changed data citation urls to dois

### DIFF
--- a/glmmTMB/man/Owls.Rd
+++ b/glmmTMB/man/Owls.Rd
@@ -28,7 +28,7 @@
   Nestling barn owls beg more intensely in the presence of their mother
   than in the presence of their father.
   \emph{Animal Behaviour} \bold{74} 1099--1106.
-  \url{https://doi.org/10.1016/j.anbehav.2007.01.027};
+  \doi{10.1016/j.anbehav.2007.01.027};
   \url{http://www.highstat.com/Books/Book2/ZuurDataMixedModelling.zip}
 }
 \references{

--- a/glmmTMB/man/Salamanders.Rd
+++ b/glmmTMB/man/Salamanders.Rd
@@ -22,9 +22,9 @@
 }
 }
 \references{
-    Price SJ, Muncy BL, Bonner SJ, Drayer AN, Barton CD (2016) Effects of mountaintop removal mining and valley filling on the occupancy and abundance of stream salamanders. \emph{Journal of Applied Ecology} \bold{53} 459--468. \url{http://dx.doi.org/10.1111/1365-2664.12585}
+    Price SJ, Muncy BL, Bonner SJ, Drayer AN, Barton CD (2016) Effects of mountaintop removal mining and valley filling on the occupancy and abundance of stream salamanders. \emph{Journal of Applied Ecology} \bold{53} 459--468. \doi{10.1111/1365-2664.12585}
   
-    Price SJ, Muncy BL, Bonner SJ, Drayer AN, Barton CD (2015) Data from: Effects of mountaintop removal mining and valley filling on the occupancy and abundance of stream salamanders. \emph{Dryad Digital Repository}. \url{http://dx.doi.org/10.5061/dryad.5m8f6} 
+    Price SJ, Muncy BL, Bonner SJ, Drayer AN, Barton CD (2015) Data from: Effects of mountaintop removal mining and valley filling on the occupancy and abundance of stream salamanders. \emph{Dryad Digital Repository}. \doi{10.5061/dryad.5m8f6} 
 }
 
 \examples{


### PR DESCRIPTION
`check --as-cran` was giving this message
```
Found the following URLs which should use \doi (with the DOI name only):
  File ‘Owls.Rd’:
    https://doi.org/10.1016/j.anbehav.2007.01.027
  File ‘Salamanders.Rd’:
    http://dx.doi.org/10.1111/1365-2664.12585
    http://dx.doi.org/10.5061/dryad.5m8f6
```
So I guess this is what they want.