### PR TITLE
Correct 'invalid' URLS #647

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![total downloads](http://cranlogs.r-pkg.org/badges/grand-total/glmmTMB)](http://cranlogs.r-pkg.org/badges/grand-total/glmmTMB)
 [![R-CMD-check](https://github.com/glmmTMB/glmmTMB/workflows/R-CMD-check/badge.svg)](https://github.com/glmmTMB/glmmTMB/actions)
 
-[GitHub pages site](https://glmmTMB.github.io/glmmTMB)
+[GitHub pages site](https://glmmTMB.github.io/glmmTMB/)
 
 `glmmTMB` is an R package for fitting generalized linear mixed models (GLMMs) and extensions, built on [Template Model Builder](https://github.com/kaskr/adcomp), which is in turn built on [CppAD](https://www.coin-or.org/CppAD/) and [Eigen](eigen.tuxfamily.org/). It handles a wide range of statistical distributions (Gaussian, Poisson, binomial, negative binomial, Beta ...) as well as model extensions such as zero-inflation, heteroscedasticity, and autocorrelation. Fixed and random effects models can be specified for the conditional and zero-inflated components of the model, as well as fixed effects models for the dispersion parameter.
 

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -22,7 +22,7 @@
   in order to install from source.
   
   As soon as the problem is resolved we hope to
-  provide pre-built binaries at \url{https://glmmTMB.github.io/glmmTMB}
+  provide pre-built binaries at \url{https://glmmTMB.github.io/glmmTMB/}
   and/or release a new minor version.
 
   \subsection{NEW FEATURES}{

--- a/glmmTMB/vignettes/parallel.Rmd
+++ b/glmmTMB/vignettes/parallel.Rmd
@@ -87,7 +87,7 @@ Now we fit the same model, but using `r nt` threads. The speed-up is more notice
 
 From [Writing R Extensions](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#OpenMP-support):
 
-> Apple builds of clang on macOS currently have no OpenMP support, but CRAN binary packages are built with a clang-based toolchain which supports OpenMP. http://www.openmp.org/resources/openmp-compilers-tools gives some idea of what compilers support what versions.
+> Apple builds of clang on macOS currently have no OpenMP support, but CRAN binary packages are built with a clang-based toolchain which supports OpenMP. https://www.openmp.org/resources/openmp-compilers-tools gives some idea of what compilers support what versions.
 
 > The performance of OpenMP varies substantially between platforms. The Windows implementation has substantial overheads, so is only beneficial if quite substantial tasks are run in parallel. Also, on Windows new threads are started with the default FPU control word, so computations done on OpenMP threads will not make use of extended-precision arithmetic which is the default for the main process. 
 ## System information


### PR DESCRIPTION
Fix 'invalid' URLS from NOTEs in last R CMD check. Noted here: https://github.com/glmmTMB/glmmTMB/issues/647#issuecomment-866910497