### PR TITLE
put omp.h include before R includes

### DIFF
--- a/glmmTMB/src/utils.cpp
+++ b/glmmTMB/src/utils.cpp
@@ -1,8 +1,9 @@
-# include <R.h>
-# include <Rinternals.h>
+/* as per BDR/CRAN, system headers must come before R headers */
 # ifdef _OPENMP
 #include <omp.h>
 # endif
+# include <R.h>
+# include <Rinternals.h>
 
 /* check if openmp is enabled */
 extern "C"


### PR DESCRIPTION
I *think* this addresses #751, although I'm not quite sure how we can test on clang 13.0 ...