### PR TITLE
Vcov names fix

### DIFF
--- a/glmmTMB/DESCRIPTION
+++ b/glmmTMB/DESCRIPTION
@@ -81,3 +81,4 @@ LazyData: TRUE
 BugReports: https://github.com/glmmTMB/glmmTMB/issues
 NeedsCompilation: yes
 Encoding: UTF-8
+RoxygenNote: 7.1.2

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -390,12 +390,12 @@ vcov.glmmTMB <- function(object, full=FALSE, include_mapped=FALSE, ...) {
       ##    res <- covF[-nrow(covF),-nrow(covF)]
 
       reNames <- function(tag) {
-          re <- object$modelInfo$reStruc[[paste0(tag,"ReStruc")]]
-          nn <- mapply(function(n,L) paste(n,seq(L),sep="."),
-                 names(re),
-                 sapply(re,"[[","blockNumTheta"))
-          if (length(nn)==0) return(nn)
-          return(paste("theta",gsub(" ","",nn),sep="_"))
+        re <- object$modelInfo$reStruc[[paste0(tag,"ReStruc")]]
+        num_theta <- vapply(re,"[[","blockNumTheta", FUN.VALUE = numeric(1))
+        nn <- mapply(function(n,L) paste(n, seq(L), sep="."),
+                     names(re), num_theta)
+        if (length(nn) == 0) return(nn)
+        return(paste("theta",gsub(" ", "", unlist(nn)), sep="_"))
       }
       ## nameList for estimated variables;
       nameList <- c(nameList,list(theta=reNames("cond"),thetazi=reNames("zi")))

--- a/glmmTMB/man/diagnose.Rd
+++ b/glmmTMB/man/diagnose.Rd
@@ -14,7 +14,8 @@ diagnose(
   check_coefs = TRUE,
   check_zstats = TRUE,
   check_hessian = TRUE,
-  check_scales = TRUE
+  check_scales = TRUE,
+  explain = TRUE
 )
 }
 \arguments{
@@ -37,6 +38,8 @@ diagnose(
 \item{check_hessian}{identify non-positive-definite Hessian components?}
 
 \item{check_scales}{identify predictors with unusually small or large scales?}
+
+\item{explain}{provide detailed explanation of each test?}
 }
 \value{
 a logical value based on whether anything questionable was found


### PR DESCRIPTION
fixed a long-standing bug in vcov(full=TRUE) (would only have useful names if there was  <= 1 RE component); improved `diagnose()` messages etc.

The troubleshooting vignette could probably still use some love (and `NEWS` file not updated for fix above).
