### PR TITLE
Use short DOI instead of expanded URL

### DIFF
--- a/glmmTMB/R/family.R
+++ b/glmmTMB/R/family.R
@@ -82,11 +82,11 @@ make_family <- function(x,link) {
 ##' \item Ferrari SLP, Cribari-Neto F (2004). "Beta Regression for Modelling Rates and Proportions." \emph{J. Appl. Stat.}  31(7), 799-815.
 ##' \item Hardin JW & Hilbe JM (2007). "Generalized linear models and extensions." Stata Press.
 ##' \item Huang A (2017). "Mean-parametrized Conway–Maxwell–Poisson regression models for dispersed counts." \emph{Statistical Modelling} 17(6), 1-22.
-##' \item Joe H, Zhu R (2005). "Generalized Poisson Distribution: The Property of Mixture of Poisson and Comparison with Negative Binomial Distribution." \emph{Biometrical Journal} 47(2): 219–29. doi:10.1002/bimj.200410102.
+##' \item Joe H, Zhu R (2005). "Generalized Poisson Distribution: The Property of Mixture of Poisson and Comparison with Negative Binomial Distribution." \emph{Biometrical Journal} 47(2): 219–29. \doi{10.1002/bimj.200410102}.
 ##' \item Morris  W (1997). "Disentangling Effects of Induced Plant Defenses and Food Quantity on Herbivores by Fitting Nonlinear Models." \emph{American Naturalist} 150:299-327.
 ##' \item Sellers K & Lotze T (2015). "COMPoissonReg: Conway-Maxwell Poisson (COM-Poisson) Regression". R package version 0.3.5. https://CRAN.R-project.org/package=COMPoissonReg
-##' \item Sellers K & Shmueli G (2010) "A Flexible Regression Model for Count Data." \emph{Annals of Applied Statistics} 4(2), 943–61. https://doi.org/10.1214/09-AOAS306.
-##' \item Shonkwiler, J. S. (2016). "Variance of the truncated negative binomial distribution." \emph{Journal of Econometrics} 195(2), 209–210. doi:10.1016/j.jeconom.2016.09.002
+##' \item Sellers K & Shmueli G (2010) "A Flexible Regression Model for Count Data." \emph{Annals of Applied Statistics} 4(2), 943–61. \doi{10.1214/09-AOAS306}.
+##' \item Shonkwiler, J. S. (2016). "Variance of the truncated negative binomial distribution." \emph{Journal of Econometrics} 195(2), 209–210. \doi{10.1016/j.jeconom.2016.09.002}.
 ##' }
 ##' @export
 ##' @importFrom stats make.link

--- a/glmmTMB/inst/CITATION
+++ b/glmmTMB/inst/CITATION
@@ -20,24 +20,23 @@ bibentry(bibtype = "Article",
          title = "{glmmTMB} Balances Speed and Flexibility Among Packages for Zero-inflated Generalized Linear Mixed Modeling",
          year = "2017",
          journal = "The R Journal",
-         url = "https://journal.r-project.org/archive/2017/RJ-2017-066/index.html",
+         doi = "10.32614/RJ-2017-066",
          pages = "378--400",
          volume = "9",
          number = "2",
          header = "To cite glmmTMB in publications use:",
-         textVersion = "Mollie E. Brooks, Kasper Kristensen, Koen J. van Benthem, Arni Magnusson, Casper W. Berg, Anders Nielsen, Hans J. Skaug, Martin Maechler and Benjamin M. Bolker (2017). glmmTMB Balances Speed and Flexibility Among Packages for Zero-inflated Generalized Linear Mixed Modeling. The R Journal, 9(2), 378-400."
+         textVersion = "Mollie E. Brooks, Kasper Kristensen, Koen J. van Benthem, Arni Magnusson, Casper W. Berg, Anders Nielsen, Hans J. Skaug, Martin Maechler and Benjamin M. Bolker (2017). glmmTMB Balances Speed and Flexibility Among Packages for Zero-inflated Generalized Linear Mixed Modeling. The R Journal, 9(2), 378-400. doi: 10.32614/RJ-2017-066."
 )
 
 ## bibentry(bibtype = "Article",
 ##  author = "Brooks, Mollie E. and Kristensen, Kasper and van Benthem, Koen J. and Magnusson, Arni and Berg, Casper W. and Nielsen, Anders and Skaug, Hans J. and Maechler, Martin and Bolker, Benjamin M.",
 ##  title = "Modeling Zero-Inflated Count Data With glmmTMB",
 ##  year = "2017",
-##  url = "http://biorxiv.org/content/early/2017/05/01/132753",
-##  eprint = "http://biorxiv.org/content/early/2017/05/01/132753.full.pdf",
+##  doi = "10.1101/132753",
 ##  journal = "bioRxiv preprint bioRxiv:132753",
 ##  archivePrefix = "bioRxiv",
 ##  header = "To cite glmmTMB in publications use one or both of the following:",
-##  textVersion = "Mollie E. Brooks, Kasper Kristensen, Koen J. van Benthem, Arni Magnusson, Casper W. Berg, Anders Nielsen, Hans J. Skaug, Martin Maechler, Benjamin M. Bolker (2017). Modeling Zero-Inflated Count Data With glmmTMB. bioRxiv preprint bioRxiv:132753; doi: https://doi.org/10.1101/132753"
+##  textVersion = "Mollie E. Brooks, Kasper Kristensen, Koen J. van Benthem, Arni Magnusson, Casper W. Berg, Anders Nielsen, Hans J. Skaug, Martin Maechler, Benjamin M. Bolker (2017). Modeling Zero-Inflated Count Data With glmmTMB. bioRxiv preprint bioRxiv:132753. doi: 10.1101/132753."
 ## )
 
 ## bibentry(bibtype = "Manual",

--- a/glmmTMB/man/nbinom2.Rd
+++ b/glmmTMB/man/nbinom2.Rd
@@ -83,10 +83,10 @@ and the \pkg{betareg} package (Cribari-Neto and Zeileis 2010); \eqn{V=\mu(1-\mu)
 \item Ferrari SLP, Cribari-Neto F (2004). "Beta Regression for Modelling Rates and Proportions." \emph{J. Appl. Stat.}  31(7), 799-815.
 \item Hardin JW & Hilbe JM (2007). "Generalized linear models and extensions." Stata Press.
 \item Huang A (2017). "Mean-parametrized Conway–Maxwell–Poisson regression models for dispersed counts." \emph{Statistical Modelling} 17(6), 1-22.
-\item Joe H, Zhu R (2005). "Generalized Poisson Distribution: The Property of Mixture of Poisson and Comparison with Negative Binomial Distribution." \emph{Biometrical Journal} 47(2): 219–29. doi:10.1002/bimj.200410102.
+\item Joe H, Zhu R (2005). "Generalized Poisson Distribution: The Property of Mixture of Poisson and Comparison with Negative Binomial Distribution." \emph{Biometrical Journal} 47(2): 219–29. \doi{10.1002/bimj.200410102}.
 \item Morris  W (1997). "Disentangling Effects of Induced Plant Defenses and Food Quantity on Herbivores by Fitting Nonlinear Models." \emph{American Naturalist} 150:299-327.
 \item Sellers K & Lotze T (2015). "COMPoissonReg: Conway-Maxwell Poisson (COM-Poisson) Regression". R package version 0.3.5. https://CRAN.R-project.org/package=COMPoissonReg
-\item Sellers K & Shmueli G (2010) "A Flexible Regression Model for Count Data." \emph{Annals of Applied Statistics} 4(2), 943–61. https://doi.org/10.1214/09-AOAS306.
-\item Shonkwiler, J. S. (2016). "Variance of the truncated negative binomial distribution." \emph{Journal of Econometrics} 195(2), 209–210. doi:10.1016/j.jeconom.2016.09.002
+\item Sellers K & Shmueli G (2010) "A Flexible Regression Model for Count Data." \emph{Annals of Applied Statistics} 4(2), 943–61. \doi{10.1214/09-AOAS306}.
+\item Shonkwiler, J. S. (2016). "Variance of the truncated negative binomial distribution." \emph{Journal of Econometrics} 195(2), 209–210. \doi{10.1016/j.jeconom.2016.09.002}.
 }
 }

--- a/glmmTMB/vignettes/glmmTMB.Rnw
+++ b/glmmTMB/vignettes/glmmTMB.Rnw
@@ -22,8 +22,12 @@
 \usepackage{natbib}
 \VerbatimFootnotes
 \bibliographystyle{chicago}
-%% need this for output of citation() below ...
+%% need these for output of citation() below ...
 \newcommand{\bold}[1]{\textbf{#1}}
+%% from Sebastian Meyer: needs LaTeX >= 2020-10-01
+%% (probably? don't need to worry about backward compatibility,
+%%  people who need to build the vignette can update?)
+\NewCommandCopy\Rhref\href
 
 \title{Getting started with the \code{glmmTMB} package}
 \author{Ben Bolker}

--- a/glmmTMB/vignettes/glmmTMB.bib
+++ b/glmmTMB/vignettes/glmmTMB.bib
@@ -17,7 +17,7 @@ year = {2007},
 journal= {Animal Behaviour},
 volume= {74},
 pages={1099-1106},
-url = {http://www.sciencedirect.com/science/article/B6W9W-4PK8B6H-8/2/e43cfbaad4dc0bb2207adfc54a460c89}
+doi = {10.1016/j.anbehav.2007.01.027}
 }
 
 @book{zuur_mixed_2009,
@@ -49,7 +49,6 @@ url = {http://www.sciencedirect.com/science/article/B6W9W-4PK8B6H-8/2/e43cfbaad4
 	volume = {24},
 	issn = {0169-5347},
 	shorttitle = {Generalized linear mixed models},
-	url = {http://www.sciencedirect.com/science/article/B6VJ1-4VGKHJP-1/2/35970065c78c14ad30bf71bd1d5b452e},
 	doi = {10.1016/j.tree.2008.10.008},
 	abstract = {How should ecologists and evolutionary biologists analyze nonnormal data that involve random effects? Nonnormal data such as counts or proportions often defy classical statistical procedures. Generalized linear mixed models {(GLMMs)} provide a more flexible approach for analyzing nonnormal data when random effects are present. The explosion of research on {GLMMs} in the last decade has generated considerable uncertainty for practitioners in ecology and evolution. Despite the availability of accurate techniques for estimating {GLMM} parameters in simple cases, complex {GLMMs} are challenging to fit and statistical inference such as hypothesis testing remains difficult. We review the use (and misuse) of {GLMMs} in ecology and evolution, discuss estimation and inference and summarize [`]best-practice' data analysis procedures for scientists facing this challenge.},
 	journal = {Trends in Ecology \& Evolution},
@@ -108,8 +107,7 @@ url = {http://www.sciencedirect.com/science/article/B6W9W-4PK8B6H-8/2/e43cfbaad4
 	volume = {10},
 	issn = {2041-210X},
 	shorttitle = {gllvm},
-	url = {https://besjournals.onlinelibrary.wiley.com/doi/abs/10.1111/2041-210X.13303},
-	doi = {https://doi.org/10.1111/2041-210X.13303},
+	doi = {10.1111/2041-210X.13303},
 	abstract = {There has been rapid development in tools for multivariate analysis based on fully specified statistical models or 'joint models'. One approach attracting a lot of attention is generalized linear latent variable models (GLLVMs). However, software for fitting these models is typically slow and not practical for large datasets. The R package gllvm offers relatively fast methods to fit GLLVMs via maximum likelihood, along with tools for model checking, visualization and inference. The main advantage of the package over other implementations is speed, for example, being two orders of magnitude faster, and capable of handling thousands of response variables. These advances come from using variational approximations to simplify the likelihood expression to be maximized, automatic differentiation software for model-fitting (via the TMB package) and careful choice of initial values for parameters. Examples are used to illustrate the main features and functionality of the package, such as constrained or unconstrained ordination, including functional traits in 'fourth corner' models, and (if the number of environmental coefficients is not large) make inferences about environmental associations.},
 	language = {en},
 	number = {12},
@@ -117,7 +115,6 @@ url = {http://www.sciencedirect.com/science/article/B6W9W-4PK8B6H-8/2/e43cfbaad4
 	journal = {Methods in Ecology and Evolution},
 	author = {Niku, Jenni and Hui, Francis K. C. and Taskinen, Sara and Warton, David I.},
 	year = {2019},
-	note = {\_eprint: https://besjournals.onlinelibrary.wiley.com/doi/pdf/10.1111/2041-210X.13303},
 	keywords = {abundance data, generalized linear latent variable models, high-dimensional data, joint modelling, maximum likelihood, multivariate analysis, ordination, species interactions},
 	pages = {2173--2182}
 }
@@ -125,8 +122,7 @@ url = {http://www.sciencedirect.com/science/article/B6W9W-4PK8B6H-8/2/e43cfbaad4
 @article{hui2015model,
 	title={Model-based approaches to unconstrained ordination},
 	volume={6},
-	url = {https://besjournals.onlinelibrary.wiley.com/doi/abs/10.1111/2041-210X.12236},
-	doi = {https://doi.org/10.1111/2041-210X.12236},
+	doi = {10.1111/2041-210X.12236},
 	abstract = {Summary
 1. Unconstrained ordination is commonly used in ecology to visualize multivariate data, in particular, to visualize
 themain trends between different sites in terms of their species composition or relative abundance.


### PR DESCRIPTION
Hi All,

Among the `R CMD check --as-cran` notes that I was seeing (I'm running R 4.1.3 on Debian 11) were:

```
Found the following (possibly) invalid URLs:
https://doi.org/https://doi.org/10.1111/2041-210X.12236
  URL: https://doi.org/https://doi.org/10.1111/2041-210X.12236
    From: inst/doc/covstruct.html
    Status: 503
    Message: Service Unavailable
  URL: https://doi.org/https://doi.org/10.1111/2041-210X.13303
    From: inst/doc/covstruct.html
    Status: 503
    Message: Service Unavailable
```

This seems like a valid note, since we don't want `https://doi.org` to appear twice in the same URL. To fix this problem, I edited `glmmTMB.bib` to change entries
```
  doi = {https://doi.org/10.1111/2041-210X.13303},
  doi = {https://doi.org/10.1111/2041-210X.12236},
```
to
```
  doi = {10.1111/2041-210X.13303},
  doi = {10.1111/2041-210X.12236},
```

Based on recent CRAN reviews of my submitted packages, they recommend using short `\doi{}` entries in documentation rather than expanded `\url{}` entries. In other words, include just the DOI, not the URL that it expands to. This recommendation is also stated in the `?bibentry` help page: "If the URL is an expanded DOI, we recommend to use the doi field with the unexpanded DOI instead."

To have the glmmTMB package follow CRAN recommendations and to have a consistent style within the package, I have:

1. Replaced `doi` with `\doi{}` in Rd files
2. Replaced `https://doi.org` with `\doi{}` in Rd files
3. Replaced `url` and `eprint` with `doi` in CITATION file
4. Replaced `doi: https://doi.org` with `doi:` in CITATION file
5. Replaced `url` with `doi` in glmmTMB.bib file
6. Replaced `doi = {https://doi.org/` with `doi = {` in glmmTMB.bib file

This results in cleaner references. For example, at the bottom of https://cran.r-project.org/web/packages/glmmTMB/vignettes/covstruct.html, we will now have a single hyperlink for each bibliographic reference, instead of two links that lead to the same webpage.

In summary, mainly a cosmetic change for consistency and to follow CRAN recommendations. Also fixes strange URLs such as `https://doi.org/https://doi.org/10.1111/2041-210X.12236` with `https://doi.org` appearing twice inside the same URL.