### PR TITLE
Fix broken doxygen links

### DIFF
--- a/glmmTMB/R/VarCorr.R
+++ b/glmmTMB/R/VarCorr.R
@@ -160,7 +160,7 @@ mkVC <- function(cor, sd, cnms, sc, useSc) {
 ##' are structured as follows: the first n parameters are the log-standard-deviations,
 ##' while the remaining n(n-1)/2 parameters are the elements of the Cholesky factor
 ##' of the correlation matrix, filled in column-wise order
-##' (see the \href{http://kaskr.github.io/adcomp/classUNSTRUCTURED__CORR__t.html}{TMB documentation}
+##' (see the \href{http://kaskr.github.io/adcomp/classdensity_1_1UNSTRUCTURED__CORR__t.html}{TMB documentation}
 ##' for further details).
 ##' @keywords internal
 VarCorr.glmmTMB <- function(x, sigma = 1, ... )

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -47,7 +47,7 @@ parallel_default <- function(parallel=c("no","multicore","snow"),ncpus=1) {
 ##' translate vector of correlation parameters to correlation values
 ##' @param theta vector of internal correlation parameters (elements of scaled Cholesky factor, in \emph{row-major} order)
 ##' @return a vector of correlation values
-##' @details This function follows the definition at \url{http://kaskr.github.io/adcomp/classUNSTRUCTURED__CORR__t.html}:
+##' @details This function follows the definition at \url{http://kaskr.github.io/adcomp/classdensity_1_1UNSTRUCTURED__CORR__t.html}:
 ##' if \eqn{L} is the lower-triangular matrix with 1 on the diagonal and the correlation parameters in the lower triangle, then the correlation matrix is defined as \eqn{\Sigma = D^{-1/2} L L^\top D^{-1/2}}{Sigma = sqrt(D) L L' sqrt(D)}, where \eqn{D = \textrm{diag}(L L^\top)}{D = diag(L L')}. For a single correlation parameter \eqn{\theta_0}{theta0}, this works out to \eqn{\rho = \theta_0/\sqrt{1+\theta_0^2}}{rho = theta0/sqrt(1+theta0^2)}. The function returns the elements of the lower triangle of the correlation matrix, in column-major order.
 ##' @examples
 ##' th0 <- 0.5

--- a/glmmTMB/man/VarCorr.glmmTMB.Rd
+++ b/glmmTMB/man/VarCorr.glmmTMB.Rd
@@ -22,7 +22,7 @@ For an unstructured variance-covariance matrix, the internal parameters
 are structured as follows: the first n parameters are the log-standard-deviations,
 while the remaining n(n-1)/2 parameters are the elements of the Cholesky factor
 of the correlation matrix, filled in column-wise order
-(see the \href{http://kaskr.github.io/adcomp/classUNSTRUCTURED__CORR__t.html}{TMB documentation}
+(see the \href{http://kaskr.github.io/adcomp/classdensity_1_1UNSTRUCTURED__CORR__t.html}{TMB documentation}
 for further details).
 }
 \examples{

--- a/glmmTMB/man/get_cor.Rd
+++ b/glmmTMB/man/get_cor.Rd
@@ -16,7 +16,7 @@ a vector of correlation values
 translate vector of correlation parameters to correlation values
 }
 \details{
-This function follows the definition at \url{http://kaskr.github.io/adcomp/classUNSTRUCTURED__CORR__t.html}:
+This function follows the definition at \url{http://kaskr.github.io/adcomp/classdensity_1_1UNSTRUCTURED__CORR__t.html}:
 if \eqn{L} is the lower-triangular matrix with 1 on the diagonal and the correlation parameters in the lower triangle, then the correlation matrix is defined as \eqn{\Sigma = D^{-1/2} L L^\top D^{-1/2}}{Sigma = sqrt(D) L L' sqrt(D)}, where \eqn{D = \textrm{diag}(L L^\top)}{D = diag(L L')}. For a single correlation parameter \eqn{\theta_0}{theta0}, this works out to \eqn{\rho = \theta_0/\sqrt{1+\theta_0^2}}{rho = theta0/sqrt(1+theta0^2)}. The function returns the elements of the lower triangle of the correlation matrix, in column-major order.
 }
 \examples{

--- a/glmmTMB/vignettes/covstruct.rmd
+++ b/glmmTMB/vignettes/covstruct.rmd
@@ -524,7 +524,7 @@ for variance parameters) and their order.
 
 ### Unstructured
 
-For an unstructured matrix of size `n`, parameters `1:n` represent the log-standard deviations while the remaining `n(n-1)/2` (i.e. `(n+1):(n:(n*(n+1)/2))`) are the elements of the *scaled* Cholesky factor of the correlation matrix, filled in row-wise order (see [TMB documentation](http://kaskr.github.io/adcomp/classUNSTRUCTURED__CORR__t.html)). In particular, if $L$ is the lower-triangular matrix with 1 on the diagonal and the correlation parameters in the lower triangle, then the correlation matrix is defined as $\Sigma = D^{-1/2} L L^\top D^{-1/2}$, where $D = \textrm{diag}(L L^\top)$. For a single correlation parameter $\theta_0$, this works out to $\rho = \theta_0/\sqrt{1+\theta_0^2}$.
+For an unstructured matrix of size `n`, parameters `1:n` represent the log-standard deviations while the remaining `n(n-1)/2` (i.e. `(n+1):(n:(n*(n+1)/2))`) are the elements of the *scaled* Cholesky factor of the correlation matrix, filled in row-wise order (see [TMB documentation](http://kaskr.github.io/adcomp/classdensity_1_1UNSTRUCTURED__CORR__t.html)). In particular, if $L$ is the lower-triangular matrix with 1 on the diagonal and the correlation parameters in the lower triangle, then the correlation matrix is defined as $\Sigma = D^{-1/2} L L^\top D^{-1/2}$, where $D = \textrm{diag}(L L^\top)$. For a single correlation parameter $\theta_0$, this works out to $\rho = \theta_0/\sqrt{1+\theta_0^2}$.
 
 (See calculations [here](https://github.com/glmmTMB/glmmTMB/blob/master/misc/glmmTMB_corcalcs.ipynb).)
 


### PR DESCRIPTION
TMB doxygen failed to pick up the namespace information on some classes. When this was fixed in TMB it changed the corresponding doxygen links.
