### PR TITLE
improve/test 'rank_check="adjust"' option

### DIFF
--- a/glmmTMB/NAMESPACE
+++ b/glmmTMB/NAMESPACE
@@ -106,6 +106,7 @@ if(getRversion() >= "3.6.0") {
 }
 if(getRversion()>='3.3.0') importFrom(stats, sigma) else importFrom(lme4,sigma)
 importFrom(Matrix,Cholesky)
+importFrom(Matrix,rankMatrix)
 importFrom(Matrix,solve)
 importFrom(Matrix,t)
 importFrom(TMB,MakeADFun)

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -1293,18 +1293,31 @@ glmmTMBControl <- function(optCtrl=NULL,
         for(whichX in Xnames){
            if(prod(dim(TMBStruc$data.tmb[[whichX]])) == 0) next
            ## QR decomposition to identify linearly dependent columns
-           qr_X <- Matrix::qr(TMBStruc$data.tmb[[whichX]], tol = 1e-7)
+           curX <- TMBStruc$data.tmb[[whichX]]
+           qr_X <- Matrix::qr(curX, tol = 1e-7)
+           if (inherits(curX, "sparseMatrix")) {
+               rr <- rankMatrix(curX)
+           } else {
+               rr <- qr_X$rank
+           }
            ## if rank-deficient, adjust X and associated fixed effect parameters
-           if(qr_X$rank < ncol(TMBStruc$data.tmb[[whichX]])){
+           if(rr < ncol(curX)) {
                model_type <- names(Xnames)[match(whichX, Xnames)]
                message("dropping columns from rank-deficient ", model_type," model")
-               ## columns to keep/drop
-               to_keep <- qr_X$pivot[1L:qr_X$rank]
-               to_drop <- qr_X$pivot[(qr_X$rank+1L):length(qr_X$pivot)]
-               dropped_names <- colnames(qr_X$qr)[to_drop]
+               ## columns to keep/drop: a hack,
+               if (inherits(curX, "sparseMatrix")) {
+                   rel_beta <- qr_X@beta/min(qr_X@beta)
+                   to_keep <- which(rel_beta <= 1e8)
+                   to_drop <- which(rel_beta > 1e8)
+                   dropped_names <- colnames(qr_X@R)[to_drop]
+               } else {
+                   to_keep <- qr_X$pivot[1L:qr_X$rank]
+                   to_drop <- qr_X$pivot[(qr_X$rank+1L):length(qr_X$pivot)]
+                   dropped_names <- colnames(qr_X$qr)[to_drop]
+               }
 
                ## update X within TMBStruc; retain dropped columns names for use in model output
-               TMBStruc$data.tmb[[whichX]] <- TMBStruc$data.tmb[[whichX]][,to_keep,drop=FALSE]
+               TMBStruc$data.tmb[[whichX]] <- curX[,to_keep,drop=FALSE]
                attr(TMBStruc$data.tmb[[whichX]], "col.dropped") <- setNames(to_drop, dropped_names)
 
                ## reduce parameters of appropriate component

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -1151,7 +1151,7 @@ glmmTMB <- function(
 ##' @param eigval_check Check eigenvalues of variance-covariance matrix? (This test may be very slow for models with large numbers of fixed-effect parameters.)
 ##' @param zerodisp_val value of the dispersion parameter when \code{dispformula=~0} is specified
 ##' @param start_method (list) Options to initialize the starting values when fitting models with reduced-rank (\code{rr}) covariance structures; \code{jitter.sd} adds variation to the starting values of latent variables when \code{method = "res"}.
-##' @param rank_check Check whether all parameters in fixed-effects models are identifiable? This test may be slow for models with large numbers of fixed-effect parameters, therefore default value is 'warn'. Alternatives include 'skip', 'stop', and 'adjust'.
+##' @param rank_check Check whether all parameters in fixed-effects models are identifiable? This test may be slow for models with large numbers of fixed-effect parameters, therefore default value is 'warning'. Alternatives include 'skip', 'stop', and 'adjust'.
 ##' @details
 ##' By default, \code{\link{glmmTMB}} uses the nonlinear optimizer
 ##' \code{\link{nlminb}} for parameter estimation. Users may sometimes
@@ -1199,7 +1199,7 @@ glmmTMBControl <- function(optCtrl=NULL,
                            eigval_check = TRUE,
                            zerodisp_val=log(sqrt(.Machine$double.eps)),
                            start_method = list(method = NULL, jitter.sd = 0),
-                           rank_check = c("warn", "adjust", "stop", "skip")) {
+                           rank_check = c("warning", "adjust", "stop", "skip")) {
 
     if (is.null(optCtrl) && identical(optimizer,nlminb)) {
         optCtrl <- list(iter.max=300, eval.max=400)
@@ -1263,67 +1263,53 @@ glmmTMBControl <- function(optCtrl=NULL,
     data.tmb
 }
 
+
 # FIXME: Should there be an @import for rankMatrix and qr below?
 ##' Check for identifiability of fixed effects matrices X, Xzi, Xd.
 ##' When rank_check='adjust', drop columns in X and remove associated parameters.
 ##' @keywords internal
-.checkRankX <- function(TMBStruc, rank_check=c('warn','adjust','stop','skip')) {
+.checkRankX <- function(TMBStruc, rank_check=c('warning','adjust','stop','skip')) {
   rank_check <- match.arg(rank_check)
-  Xnames <- c("X", "XS", "Xzi", "XziS", "Xd", "XdS")
+  Xnames <- c(conditional = "X", conditional = "XS", "zero-inflation" = "Xzi", "zero-inflation" = "XziS", dispersion = "Xd", dispersion = "XdS")
+  betanames <- gsub("X", "beta",
+                    gsub("S", "", Xnames))
   # use svd-based Matrix::rankMatrix(X) if we wish to abort or warn
   # FIXME: possibly should be an lapply? but I wanted easy access to nm to make error and warnings more informative
-  if(rank_check %in% c('stop', 'warn')){
-    for(whichX in Xnames){
+  if(rank_check %in% c('stop', 'warning')){
+    for (whichX in Xnames) {
       # only attempt rankMatrix if the X matrix contains info
-      if(prod(dim(TMBStruc$data.tmb[[whichX]]))> 0){
-        # if X is rank deficient, stop or throw a warning
-        if(Matrix::rankMatrix(TMBStruc$data.tmb[[whichX]]) < ncol(TMBStruc$data.tmb[[whichX]])){
+      if(prod(dim(TMBStruc$data.tmb[[whichX]])) == 0) next
+        ## if X is rank deficient, stop or throw a warning
+        if (Matrix::rankMatrix(TMBStruc$data.tmb[[whichX]]) < ncol(TMBStruc$data.tmb[[whichX]])){
           # determine the model type for a more indicative error or warning message
-          model_type <- switch(
-            whichX,
-            X = "conditional",
-            XS = "conditional",
-            Xzi = "zero-inflation",
-            XziS = "zero-inflation",
-            Xd = "dispersion",
-            XdS = "dispersion"
-          )
-          if(rank_check == 'stop'){
-            stop("fixed effects in ",model_type," model are rank deficient")
-          }else{
-            warning("fixed effects in ",model_type," model are rank deficient")
-          }
-        }
-      }
-    }
-  }else
-  # use Matrix::qr(X) if we are prepared to drop columns
-  if(rank_check == 'adjust'){
-    for(whichX in Xnames){
-      # start with a QR decomposition to identify linearly dependent columns
-      qr.X <- Matrix::qr(TMBStruc$data.tmb[[whichX]], tol = 1e-7)
-      # if QR indicates rank deficiency, proceed to adjust X matrix used in fit and associated fixed effect parameters
-      if(qr.X$rank < ncol(TMBStruc$data.tmb[[whichX]])){
-        # columns that will be kept and columns that will be dropped
-        to_keep <- qr.X$pivot[1L:qr.X$rank]
-        to_drop <- qr.X$pivot[(qr.X$rank+1L):length(qr.X$pivot)]
-        dropped_names <- colnames(qr.X$qr)[to_drop]
+          model_type <- names(Xnames)[match(whichX, Xnames)]
+          action <- get(rank_check, "package:base")
+          action("fixed effects in ", model_type," model are rank deficient")
+        } ## if rank-deficient
+      } ## loop over X components
+  } else
+      ## use Matrix::qr(X) if we are prepared to drop columns
+      if(rank_check == 'adjust'){
+        for(whichX in Xnames){
+           if(prod(dim(TMBStruc$data.tmb[[whichX]])) == 0) next
+           ## QR decomposition to identify linearly dependent columns
+           qr_X <- Matrix::qr(TMBStruc$data.tmb[[whichX]], tol = 1e-7)
+           ## if rank-deficient, adjust X and associated fixed effect parameters
+           if(qr_X$rank < ncol(TMBStruc$data.tmb[[whichX]])){
+               model_type <- names(Xnames)[match(whichX, Xnames)]
+               message("dropping columns from rank-deficient ", model_type," model")
+               ## columns to keep/drop
+               to_keep <- qr_X$pivot[1L:qr_X$rank]
+               to_drop <- qr_X$pivot[(qr_X$rank+1L):length(qr_X$pivot)]
+               dropped_names <- colnames(qr_X$qr)[to_drop]
 
-        # update TMBStruc to have new X with only some columns kept; retain names of dropped columns for use in model output
-        TMBStruc$data.tmb[[whichX]] <- TMBStruc$data.tmb[[whichX]][,to_keep,drop=FALSE]
-        attr(TMBStruc$data.tmb[[whichX]], "col.dropped") <- setNames(to_drop, dropped_names)
+               ## update X within TMBStruc; retain dropped columns names for use in model output
+               TMBStruc$data.tmb[[whichX]] <- TMBStruc$data.tmb[[whichX]][,to_keep,drop=FALSE]
+               attr(TMBStruc$data.tmb[[whichX]], "col.dropped") <- setNames(to_drop, dropped_names)
 
-        # use whichX to determine which beta vector needs to be reduced and reduce parameters accordingly
-        beta_name <- switch(
-          whichX,
-          X = "beta",
-          XS = "beta",
-          Xzi = "betazi",
-          XziS = "betazi",
-          Xd = "betad",
-          XdS = "betad"
-        )
-        TMBStruc$parameters[[beta_name]] <- TMBStruc$parameters[[beta_name]][to_keep]
+               ## reduce parameters of appropriate component
+               beta_name <- betanames[match(whichX, Xnames)]
+               TMBStruc$parameters[[beta_name]] <- TMBStruc$parameters[[beta_name]][to_keep]
       }
     }
   }
@@ -1380,7 +1366,7 @@ fitTMB <- function(TMBStruc) {
         TMBStruc$data.tmb <- .collectDuplicates(TMBStruc$data.tmb)
     }
 
-    if(control$rank_check %in% c('warn','stop','adjust')){
+    if(control$rank_check %in% c('warning','stop','adjust')){
       TMBStruc <- .checkRankX(TMBStruc, control$rank_check)
     }
 

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -1263,10 +1263,9 @@ glmmTMBControl <- function(optCtrl=NULL,
     data.tmb
 }
 
-
-# FIXME: Should there be an @import for rankMatrix and qr below?
 ##' Check for identifiability of fixed effects matrices X, Xzi, Xd.
 ##' When rank_check='adjust', drop columns in X and remove associated parameters.
+##' @importFrom Matrix rankMatrix
 ##' @keywords internal
 .checkRankX <- function(TMBStruc, rank_check=c('warning','adjust','stop','skip')) {
   rank_check <- match.arg(rank_check)

--- a/glmmTMB/man/dot-checkRankX.Rd
+++ b/glmmTMB/man/dot-checkRankX.Rd
@@ -5,7 +5,7 @@
 \title{Check for identifiability of fixed effects matrices X, Xzi, Xd.
 When rank_check='adjust', drop columns in X and remove associated parameters.}
 \usage{
-.checkRankX(TMBStruc, rank_check = c("warn", "adjust", "stop", "skip"))
+.checkRankX(TMBStruc, rank_check = c("warning", "adjust", "stop", "skip"))
 }
 \description{
 Check for identifiability of fixed effects matrices X, Xzi, Xd.

--- a/glmmTMB/man/glmmTMBControl.Rd
+++ b/glmmTMB/man/glmmTMBControl.Rd
@@ -14,7 +14,7 @@ glmmTMBControl(
   eigval_check = TRUE,
   zerodisp_val = log(sqrt(.Machine$double.eps)),
   start_method = list(method = NULL, jitter.sd = 0),
-  rank_check = c("warn", "adjust", "stop", "skip")
+  rank_check = c("warning", "adjust", "stop", "skip")
 )
 }
 \arguments{
@@ -44,7 +44,7 @@ set to 1, with a warning if this overrides the user-specified value.}
 
 \item{start_method}{(list) Options to initialize the starting values when fitting models with reduced-rank (\code{rr}) covariance structures; \code{jitter.sd} adds variation to the starting values of latent variables when \code{method = "res"}.}
 
-\item{rank_check}{Check whether all parameters in fixed-effects models are identifiable? This test may be slow for models with large numbers of fixed-effect parameters, therefore default value is 'warn'. Alternatives include 'skip', 'stop', and 'adjust'.}
+\item{rank_check}{Check whether all parameters in fixed-effects models are identifiable? This test may be slow for models with large numbers of fixed-effect parameters, therefore default value is 'warning'. Alternatives include 'skip', 'stop', and 'adjust'.}
 }
 \description{
 Control parameters for glmmTMB optimization

--- a/glmmTMB/tests/testthat/test-checkRank.R
+++ b/glmmTMB/tests/testthat/test-checkRank.R
@@ -28,20 +28,33 @@ test_that("error messages for non-identifiable fixed effects", {
 
 test_that("warning messages for non-identifiable fixed effects", {
     expect_warning(
-        glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warn')),
+        glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warning')),
         "fixed effects in conditional model are rank deficient"
     )
     expect_warning(
-        glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warn')),
+        glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warning')),
         "fixed effects in zero-inflation model are rank deficient"
     )
     expect_warning(
-        glmmTMB(y ~ 1, dispformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warn')),
+        glmmTMB(y ~ 1, dispformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warning')),
         "fixed effects in dispersion model are rank deficient"
     )
 })
 
-# FIXME: what tests can be performed for rank_check="adjust"?
+test_that("messages messages for non-identifiable fixed effects", {
+    expect_message(
+        m1 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='adjust')),
+        "dropping columns.*conditional")
+    expect_equal(length(fixef(m1)$cond), 3L)
+    expect_message(
+        m1 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='adjust')),
+        "dropping columns.*zero-inflation")
+    expect_equal(length(fixef(m1)$zi), 3L)
+    expect_message(
+        m1 <- glmmTMB(y ~ 1, dispformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='adjust')),
+        "dropping columns.*dispersion")
+    expect_equal(length(fixef(m1)$disp), 3L)
+})
 
 # FIXME: what tests can be performed for rank_check="skip"? maybe just check that 'skip' and 'warn' give equivalent results?
 


### PR DESCRIPTION
this fixes a bug in `glmmTMBControl(rank_check = "adjust")` (wasn't skipping empty matrices) and does a little bit of extra cleanup (option is now "warning" rather than "warn" so we can automatically `get()` the appropriate action). Also adds some tests.

Advances #830 (but should probably still be kept open, further room for improvement)