### PR TITLE
fix log_nzprob for non-fast predictions

### DIFF
--- a/glmmTMB/DESCRIPTION
+++ b/glmmTMB/DESCRIPTION
@@ -87,4 +87,4 @@ LazyData: TRUE
 BugReports: https://github.com/glmmTMB/glmmTMB/issues
 NeedsCompilation: yes
 Encoding: UTF-8
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2

--- a/glmmTMB/R/predict.R
+++ b/glmmTMB/R/predict.R
@@ -205,7 +205,7 @@ predict.glmmTMB <- function(object,
     dd$ziPredictCode <- ziPredCode
     assign("data",dd, ee) ## stick this in the appropriate environment
     newObj <- object$obj
-
+    
     ## restore original values to environment of the object
     ## putting add=TRUE first would be more readable,
     ##  but that tickles a bug in R < 4.0.2

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -41,6 +41,10 @@
 	\item ordered beta regression as in Kubinec (2022), for
 	proportion data containing exact 0 and 1 values, is now
 	implemented (\code{\link{ordbeta}})
+	\item \code{glmmTMBControl} now has a \code{conv_check} argument
+	that allows suppressing convergence warnings
+	(the intended use is when these warnings are irrelevant,
+	e.g. when running small examples for testing purposes)
     } % itemize
   } % new features
 } % version 1.1.5

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -12,7 +12,7 @@
 	\item all standard deviations are now printed in output for
 	models using \code{cs()} (GH #851)
 	\item corrected conditional and response predictions for
-	truncated distributions (GH #634, #860)
+	truncated distributions (GH #634, #860, #873)
 	\item \code{ranef()} now works correctly for families
 	with extra parameters (Tweedie etc.) (GH #870)
       } % itemize
@@ -22,7 +22,7 @@
 	\item glmmTMB now stops if fixed-effect model matrices are
 	rank deficient (i.e., perfectly collinear predictors); this
 	can be changed to a warning via
-	\code{glmmTMBControl(rank_check="ignore") (Daniel B. Stouffer)}
+	\code{glmmTMBControl(rank_check="skip") (Daniel B. Stouffer)}
 	\item the vector of "extra" family parameters
 	(Tweedie power, Student-t df,
 	etc.) has been renamed from "thetaf" to "psi"; \code{start}

--- a/glmmTMB/man/downstream_methods.Rd
+++ b/glmmTMB/man/downstream_methods.Rd
@@ -7,7 +7,7 @@
 \alias{emmeans.glmmTMB}
 \title{Downstream methods}
 \usage{
-\method{Anova}{glmmTMB}(
+Anova.glmmTMB(
   mod,
   type = c("II", "III", 2, 3),
   test.statistic = c("Chisq", "F"),
@@ -17,7 +17,7 @@
   ...
 )
 
-\method{Effect}{glmmTMB}(focal.predictors, mod, ...)
+Effect.glmmTMB(focal.predictors, mod, ...)
 }
 \arguments{
 \item{mod}{a glmmTMB model}

--- a/glmmTMB/man/glmmTMBControl.Rd
+++ b/glmmTMB/man/glmmTMBControl.Rd
@@ -14,7 +14,8 @@ glmmTMBControl(
   eigval_check = TRUE,
   zerodisp_val = log(sqrt(.Machine$double.eps)),
   start_method = list(method = NULL, jitter.sd = 0),
-  rank_check = c("warning", "adjust", "stop", "skip")
+  rank_check = c("warning", "adjust", "stop", "skip"),
+  conv_check = c("warning", "skip")
 )
 }
 \arguments{
@@ -44,7 +45,9 @@ set to 1, with a warning if this overrides the user-specified value.}
 
 \item{start_method}{(list) Options to initialize the starting values when fitting models with reduced-rank (\code{rr}) covariance structures; \code{jitter.sd} adds variation to the starting values of latent variables when \code{method = "res"}.}
 
-\item{rank_check}{Check whether all parameters in fixed-effects models are identifiable? This test may be slow for models with large numbers of fixed-effect parameters, therefore default value is 'warning'. Alternatives include 'skip', 'stop', and 'adjust'.}
+\item{rank_check}{Check whether all parameters in fixed-effects models are identifiable? This test may be slow for models with large numbers of fixed-effect parameters, therefore default value is 'warning'. Alternatives include 'skip' (no check), 'stop' (throw an error), and 'adjust' (drop redundant columns from the fixed-effect model matrix).}
+
+\item{conv_check}{Do basic checks of convergence (check for non-positive definite Hessian and non-zero convergence code from optimizer). Default is 'warning'; 'skip' ignores these tests (not recommended for general use!)}
 }
 \description{
 Control parameters for glmmTMB optimization

--- a/glmmTMB/src/glmmTMB.cpp
+++ b/glmmTMB/src/glmmTMB.cpp
@@ -37,6 +37,15 @@ enum valid_family {
   tweedie_family = 700
 };
 
+// capitalize Family so this doesn't get picked up by the 'enum' scraper
+bool trunc_Family(int family) {
+  return (family == truncated_poisson_family ||
+	  family == truncated_genpois_family ||
+	  family == truncated_compois_family ||
+	  family == truncated_nbinom1_family ||
+	  family == truncated_nbinom2_family);
+}
+
 enum valid_link {
   log_link                 = 0,
   logit_link               = 1,
@@ -151,6 +160,39 @@ Type log1m_inverse_linkfun(Type eta, int link) {
   default:
     ans = logspace_sub(Type(0), log( inverse_linkfun(eta, link) ));
   } // End switch
+  return ans;
+}
+
+/* log-prob of non-zero value in conditional distribution  */
+template<class Type>
+Type calc_log_nzprob(Type mu, Type phi, Type eta, Type etad, int family,
+		     int link) {
+  Type ans, s1, s2, s3;
+  switch (family) {
+  case truncated_nbinom1_family:
+    s3 = logspace_add( Type(0), etad);      // log(1. + phi(i)
+    ans = logspace_sub( Type(0), -mu / phi * s3 ); // 1-prob(0)
+    break;
+  case truncated_nbinom2_family:
+    // s1 is repeated computation from main loop ...
+    s1 = log_inverse_linkfun(eta, link);          // log(mu)
+    // s3 := log( 1. + mu(i) / phi(i) )
+    s3 = logspace_add( Type(0), s1 - etad );
+    ans = logspace_sub( Type(0), -phi * s3 );
+    break;
+  case truncated_poisson_family:
+    ans = logspace_sub(Type(0), -mu);  // log(1-exp(-mu(i))) = P(x>0)
+    break;
+  case truncated_genpois_family:
+    s1 = mu / sqrt(phi); //theta
+    s2 = Type(1) - Type(1)/sqrt(phi); //lambda
+    ans = logspace_sub(Type(0), -s1);
+    break;
+  case truncated_compois_family:
+    ans = logspace_sub(Type(0), dcompois2(Type(0), mu, 1/phi, true));
+    break;
+  default: ans = Type(0);
+  }
   return ans;
 }
 
@@ -543,7 +585,15 @@ Type objective_function<Type>::operator() ()
   vector<Type> pz = invlogit(etazi);
   vector<Type> phi = exp(etad);
   vector<Type> log_nzprob(eta.size());
-  log_nzprob.setZero();
+  if (!trunc_Family(family)) {
+    log_nzprob.setZero();
+  } else {
+    for (int i = 0; i < log_nzprob.size(); i++) {
+      log_nzprob(i) =  calc_log_nzprob(mu(i), phi(i), eta(i), etad(i),
+				       family, link);
+    }
+  }
+
 
 // "zero-truncated" likelihood: ignore zeros in positive distributions
 // exact zero: use for positive distributions (Gamma, beta)
@@ -633,8 +683,6 @@ Type objective_function<Type>::operator() ()
 			yobs(i) = rnbinom2(s1, s2);
 		}
 	} else {
-          s3 = logspace_add( Type(0), etad(i) );                // log(1. + phi(i)
-          log_nzprob(i) = logspace_sub( Type(0), -mu(i) / phi(i) * s3 ); // 1-prob(0)
           tmp_loglik -= log_nzprob(i);
 	  tmp_loglik = zt_lik_nearzero(yobs(i), tmp_loglik);
           SIMULATE{
@@ -654,9 +702,6 @@ Type objective_function<Type>::operator() ()
           yobs(i) = rnbinom2(s1, s2);
         }
         if (family == truncated_nbinom2_family) {
-          // s3 := log( 1. + mu(i) / phi(i) )
-          s3         = logspace_add( Type(0), s1 - etad(i) );
-          log_nzprob(i) = logspace_sub( Type(0), -phi(i) * s3 );
           tmp_loglik -= log_nzprob(i);
           tmp_loglik = zt_lik_nearzero( yobs(i), tmp_loglik);
           SIMULATE{
@@ -665,7 +710,6 @@ Type objective_function<Type>::operator() ()
         }
         break;
       case truncated_poisson_family:
-        log_nzprob(i) = logspace_sub(Type(0), -mu(i));  // log(1-exp(-mu(i))) = P(x>0)
         tmp_loglik = dpois(yobs(i), mu(i), true) - log_nzprob(i);
         tmp_loglik = zt_lik_nearzero(yobs(i), tmp_loglik);
         SIMULATE{
@@ -681,7 +725,6 @@ Type objective_function<Type>::operator() ()
       case truncated_genpois_family:
         s1 = mu(i) / sqrt(phi(i)); //theta
         s2 = Type(1) - Type(1)/sqrt(phi(i)); //lambda
-        log_nzprob(i) = logspace_sub(Type(0), -s1);
         tmp_loglik = zt_lik_nearzero(yobs(i),
 		    glmmtmb::dgenpois(yobs(i), s1, s2, true) - log_nzprob(i));
         SIMULATE{yobs(i)=glmmtmb::rtruncated_genpois(mu(i) / sqrt(phi(i)), Type(1) - Type(1)/sqrt(phi(i)));}
@@ -794,12 +837,7 @@ Type objective_function<Type>::operator() ()
       mu = phi;
     }
   } else {
-    // FIXME: would a 'truncated_family' flag be useful?
-    if (family == truncated_poisson_family ||
-	family == truncated_genpois_family ||
-	family == truncated_compois_family ||
-	family == truncated_nbinom1_family ||
-	family == truncated_nbinom2_family) {
+    if (trunc_Family(family)) {
       // convert from mean of *un-truncated* to mean of *truncated* distribution
       mu /= exp(log_nzprob);
     }
@@ -823,7 +861,6 @@ Type objective_function<Type>::operator() ()
   whichPredict -= 1; // R-index -> C-index
   vector<Type> mu_predict = mu(whichPredict);
   vector<Type> eta_predict = eta(whichPredict);
-
 
   REPORT(mu_predict);
   REPORT(eta_predict);

--- a/glmmTMB/tests/testthat/test-checkRank.R
+++ b/glmmTMB/tests/testthat/test-checkRank.R
@@ -121,17 +121,15 @@ test_that("equivalence between 'skip' and 'warn' when confronted with identifiab
     m2 <- glmmTMB(y ~ 1, dispformula = ~ x1 + x2, data=dat, control=glmmTMBControl(rank_check='warn'), sparseX=c(disp=TRUE))
     expect_equal(fixef(m1), fixef(m2))
     # models with identifiability issues
-    # X
-    expect_warning(m1 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip')),
-                   ## no rank-def warning, but we do have convergence issues
-                   "Model convergence problem")
+    ## X
+    cc1 <- glmmTMBControl(rank_check = 'skip', conv_check = 'skip')
+    m1 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=cc1)
     expect_warning(
         m2 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warn')),
         "fixed effects in conditional model are rank deficient"
     )
     expect_equal(fixef(m1), fixef(m2))
-    expect_warning(m1 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip')),
-                   "Model convergence problem")
+    m1 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=cc1)
     expect_warning(
         m2 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warn')),
         "fixed effects in zero-inflation model are rank deficient"
@@ -144,15 +142,13 @@ test_that("equivalence between 'skip' and 'warn' when confronted with identifiab
     )
     expect_equal(fixef(m1), fixef(m2))
     # sparse X
-    expect_warning(m1 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip'), sparseX=c(cond=TRUE)),
-                   "Model convergence problem")
+    m1 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=cc1)
     expect_warning(
         m2 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warn'), sparseX=c(cond=TRUE)),
         "fixed effects in conditional model are rank deficient"
     )
     expect_equal(fixef(m1), fixef(m2))
-    expect_warning(m1 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip'), sparseX=c(zi=TRUE)),
-                   "Model convergence problem")
+    m1 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control = cc1, sparseX=c(zi=TRUE))
     expect_warning(
         m2 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warn'), sparseX=c(zi=TRUE)),
         "fixed effects in zero-inflation model are rank deficient"

--- a/glmmTMB/tests/testthat/test-checkRank.R
+++ b/glmmTMB/tests/testthat/test-checkRank.R
@@ -122,13 +122,16 @@ test_that("equivalence between 'skip' and 'warn' when confronted with identifiab
     expect_equal(fixef(m1), fixef(m2))
     # models with identifiability issues
     # X
-    m1 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip'))
+    expect_warning(m1 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip')),
+                   ## no rank-def warning, but we do have convergence issues
+                   "Model convergence problem")
     expect_warning(
         m2 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warn')),
         "fixed effects in conditional model are rank deficient"
     )
     expect_equal(fixef(m1), fixef(m2))
-    m1 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip'))
+    expect_warning(m1 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip')),
+                   "Model convergence problem")
     expect_warning(
         m2 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warn')),
         "fixed effects in zero-inflation model are rank deficient"
@@ -141,13 +144,15 @@ test_that("equivalence between 'skip' and 'warn' when confronted with identifiab
     )
     expect_equal(fixef(m1), fixef(m2))
     # sparse X
-    m1 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip'), sparseX=c(cond=TRUE))
+    expect_warning(m1 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip'), sparseX=c(cond=TRUE)),
+                   "Model convergence problem")
     expect_warning(
         m2 <- glmmTMB(y ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warn'), sparseX=c(cond=TRUE)),
         "fixed effects in conditional model are rank deficient"
     )
     expect_equal(fixef(m1), fixef(m2))
-    m1 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip'), sparseX=c(zi=TRUE))
+    expect_warning(m1 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='skip'), sparseX=c(zi=TRUE)),
+                   "Model convergence problem")
     expect_warning(
         m2 <- glmmTMB(y ~ 1, ziformula = ~ x1 + x2 + x3 + x4, data=dat, control=glmmTMBControl(rank_check='warn'), sparseX=c(zi=TRUE)),
         "fixed effects in zero-inflation model are rank deficient"

--- a/glmmTMB/tests/testthat/test-predict.R
+++ b/glmmTMB/tests/testthat/test-predict.R
@@ -449,3 +449,31 @@ test_that("nzprob doesn't segfault", {
                  c(0.465946249085321, 0.206712238705304, 0.133580349579438))
 })
 
+## GH #873 continued
+test_that("nzprob computed for non-fast pred", {
+    set.seed(101)
+    dd <- data.frame(y = rpois(5, lambda = 1))
+    m1 <- glmmTMB(
+        y ~ 1,
+        ziformula = ~ 1,
+        data = dd,
+        family = truncated_poisson()
+    )
+    expect_identical(predict(m1, type = "response"),
+                     predict(m1, type = "response", fast = FALSE))
+    m2 <- update(m1, family = truncated_nbinom1)
+    expect_identical(predict(m2, type = "response"),
+                     predict(m2, type = "response", fast = FALSE))
+    m2 <- update(m1, family = truncated_nbinom2)
+    ## need more data to fit compois, genpois
+    dd2 <- data.frame(y = rpois(100, lambda = 1))
+    m2 <- update(m1, family = truncated_compois, data = dd2)
+    expect_identical(predict(m2, type = "response"),
+                     predict(m2, type = "response", fast = FALSE))
+    ## suppress NA/NaN function eval warning
+    m2 <- suppressWarnings(update(m1, family = truncated_genpois, data = dd2))
+    expect_identical(predict(m2, type = "response"),
+                     predict(m2, type = "response", fast = FALSE))
+})
+
+                 


### PR DESCRIPTION
I think this fixes the last issue highlighted in #873 (it took some rearranging ...)
Also cleans up a few warnings thrown by `test-checkRank` tests