### PR TITLE
drop dims from single-column matrix responses

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -1237,7 +1237,7 @@ glmmTMB <- function(
 
     ## extract response variable
     ## (name *must* be 'y' to match guts of family()$initialize
-    y <- fr[,respCol]
+    y <- drop(fr[[respCol]])
     ## extract response variable
     ## (name *must* be 'y' to match guts of family()$initialize
     if (is.matrix(y)) {

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -35,6 +35,8 @@
 	\item \code{model.matrix} now returns the fixed-effect model matrix
 	actually used in fitting (including dropping columns for
 	rank-deficiency)
+	\item \code{glmmTMB} now accepts single-column matrices (e.g. as
+	produced by \code{scale} as response variables
       } %inner itemize
     } % itemize
   } % user-visible changes

--- a/glmmTMB/tests/testthat/test-basics.R
+++ b/glmmTMB/tests/testthat/test-basics.R
@@ -331,5 +331,5 @@ test_that("bar/double-bar bug with gaussian response", {
 test_that("drop dimensions in response variable", {
     ## GH #937
     mm <- transform(mtcars, mpg = scale(mpg))
-    expect_is(glmmTMB(mpg ~ cyl, mm))
+    expect_is(glmmTMB(mpg ~ cyl, mm), "glmmTMB")
 })

--- a/glmmTMB/tests/testthat/test-basics.R
+++ b/glmmTMB/tests/testthat/test-basics.R
@@ -327,3 +327,9 @@ test_that("bar/double-bar bug with gaussian response", {
                c(`(Intercept)` = 2.09164503130437, cov = -0.0228597948394547))
 
 })
+
+test_that("drop dimensions in response variable", {
+    ## GH #937
+    mm <- transform(mtcars, mpg = scale(mpg))
+    expect_is(glmmTMB(mpg ~ cyl, mm))
+})


### PR DESCRIPTION
Maybe we can sneak this into the next release, since it's minor
