### PR TITLE
Size assign

### DIFF
--- a/glmmTMB/DESCRIPTION
+++ b/glmmTMB/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: glmmTMB
 Title: Generalized Linear Mixed Models using Template Model Builder
-Version: 1.1.8
+Version: 1.1.8-9000
 Authors@R: c(person("Mollie","Brooks",
 		comment=c(ORCID="0000-0001-6963-8326"),
 		role = c("aut", "cre"),

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -220,7 +220,7 @@ startParams <- function(parameters,
 ##' @param fr model frame
 ##' @param yobs observed y
 ##' @param respCol response column
-##' @param size number of trials in binomial and betabinomial families
+##' @param weights model weights (for binomial-type models, used as size/number of trials)
 ##' @param family family object
 ##' @param se (logical) compute standard error?
 ##' @param call original \code{glmmTMB} call
@@ -238,9 +238,8 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
                        respCol,
                        ## no conditional offset argument
                        ##  (should be stored in model frame)
-                       weights,
+                       weights = NULL,
                        contrasts,
-                       size=NULL,
                        family,
                        se=NULL,
                        call=NULL,
@@ -329,10 +328,12 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
 
     grpVar <- with(condList, getGrpVar(reTrms$flist))
 
-    nobs <- nrow(fr)
+   nobs <- nrow(fr)
+    
+   if (is.null(weights)) weights <- rep(1, nobs)
 
-  if (is.null(weights)) weights <- rep(1, nobs)
-
+  size <- numeric(0)
+    
   ## binomial family:
   ## binomial()$initialize was only executed locally
   ## yobs could be a factor -> treat as binary following glm
@@ -352,19 +353,15 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
         size <- yobs[,1] + yobs[,2]
         yobs <- yobs[,1] #successes
       } else {
-      if(all(yobs %in% c(0,1))) { #binary
-        size <- rep(1, nobs)
-      } else { #proportions
-          yobs <- weights * yobs
-          ## FIXME: check for non-integer values? Or does glm()
-          ##  initialization check this already?
+          ## previously tested for binary data
+          ## shouldn't need to do this, as weights is a vector of ones
+          ## by default (see NEWS for 1.1.8-9000/1.1.9)
+          yobs <- weights*yobs
           size <- weights
-          weights <- rep(1, nobs)
-        }
+          weights <- rep(1.0, nobs)
       }
     }
   }
-  if (is.null(size)) size <- numeric(0)
 
 
   denseXval <- function(component,lst) if (sparseX[[component]]) matrix(nrow=0,ncol=0) else lst$X

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -1096,27 +1096,8 @@ glmmTMB <- function(
     ##                       control = glmerControl(), ...) {
     call <- mf <- mc <- match.call()
 
-    if (is.character(family)) {
-        if (family=="beta") {
-            family <- "beta_family"
-            warning("please use ",sQuote("beta_family()")," rather than ",
-                    sQuote("\"beta\"")," to specify a Beta-distributed response")
-        }
-        family <- get(family, mode = "function", envir = parent.frame())
-    }
-
-    if (is.function(family)) {
-        ## call family with no arguments
-        family <- family()
-    }
-
-    ## FIXME: what is this doing? call to a function that's not really
-    ##  a family creation function?
-    if (is.null(family$family)) {
-      print(family)
-      stop("'family' not recognized")
-    }
-
+    family <- get_family(family)
+    
     fnames <- names(family)
     if (!all(c("family","link") %in% fnames))
         stop("'family' must contain at least 'family' and 'link' components")

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -564,7 +564,8 @@ make_pars <- function(pars, ...) {
 ##' See \code{vignette("sim", package = "glmmTMB")} for more details and examples,
 ##' and \code{vignette("covstruct", package = "glmmTMB")}
 ##' for more information on the parameterization of different covariance structures.
-##' 
+##'
+##' @inheritParams glmmTMB
 ##' @param object a \emph{one-sided} model formula (e.g. \code{~ a + b + c}
 ##' (peculiar naming is for consistency with the generic function, which typically
 ##' takes a fitted model object)
@@ -598,7 +599,10 @@ make_pars <- function(pars, ...) {
 simulate_new <- function(object,
                          nsim = 1,
                          seed = NULL,
+                         family = gaussian,
                          newdata, newparams, ..., show_pars = FALSE) {
+    
+    family <- get_family(family)
     if (!is.null(seed)) set.seed(seed)
     ## truncate
     if (length(object) == 3) stop("simulate_new should take a one-sided formula")
@@ -607,16 +611,12 @@ simulate_new <- function(object,
     form[[3]] <- form[[2]]
     form[[2]] <- quote(..y)
     ## insert a legal value: 1.0 is OK as long as family != "beta_family"
-    ## FIXME: need to be more careful; for binomial-type models, size is
-    ## only populated from the weights argument if the values are not
-    ## all (0,1). (This is arguably a limitation in the glmmTMB code:
-    ## someone *could* have data with size>1 *and* all responses in (0,1)
-    ## (although that would be pathological) ...
-    newdata[["..y"]] <- if (!identical(list(...)$family, "beta_family")) 1.0 else 0.5
+    newdata[["..y"]] <- if (family$family == "beta_family") 1.0 else 0.5
     r1 <- glmmTMB(form,
-              data = newdata,
-              ...,
-              doFit = FALSE)
+                  data = newdata,
+                  family = family,
+                  ...,
+                  doFit = FALSE)
 ## construct TMB object, but don't fit it
     r2 <- fitTMB(r1, doOptim = FALSE)
     if (show_pars) return(r2$env$last.par)
@@ -630,4 +630,28 @@ simulate_new <- function(object,
     if (is.null(x)) 
         y
     else x
+}
+
+get_family <- function(family) {
+    if (is.character(family)) {
+        if (family=="beta") {
+            family <- "beta_family"
+            warning("please use ",sQuote("beta_family()")," rather than ",
+                    sQuote("\"beta\"")," to specify a Beta-distributed response")
+        }
+        family <- get(family, mode = "function", envir = parent.frame(2))
+    }
+
+    if (is.function(family)) {
+        ## call family with no arguments
+        family <- family()
+    }
+
+    ## FIXME: what is this doing? call to a function that's not really
+    ##  a family creation function?
+    if (is.null(family$family)) {
+      print(family)
+      stop("after evaluation, 'family' must have a '$family' element")
+    }
+    return(family)
 }

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -4,7 +4,23 @@
 \title{glmmTMB News}
 \encoding{UTF-8}
 
-\section{CHANGES IN VERSION 1.1.8}{
+\section{CHANGES IN VERSION 1.1.8-9000}{
+  \subsection{USER-VISIBLE CHANGES}{
+    \itemize{
+      \item interpretation of the \emph{weights} variable for
+      binomial-type GL(M)Ms has changed. Previously, the \emph{weights}
+      argument was \emph{ignored} for a vector- (rather than
+      matrix-valued) numeric response, if all observations were either 0 or 1.
+      Now the \emph{weights} variable is multiplied by the resonse
+      variable to compute the number of successes (consistently with
+      \code{stats::glm(., family = "binomial")}). (This change makes
+      it easier to use \emph{weights} to specify the number of trials
+      per observation for \code{simulate_new()}.)
+    } % itemize
+  } % user-visible changes
+} % 1.1.8-9000
+
+\section{CHANGES IN VERSION 1.1.8 (2023-10-07)}{
   \subsection{NEW FEATURES}{
     \itemize{
       \item "lognormal" family available (log-Normal, parameterized

--- a/glmmTMB/man/mkTMBStruc.Rd
+++ b/glmmTMB/man/mkTMBStruc.Rd
@@ -13,9 +13,8 @@ mkTMBStruc(
   fr,
   yobs,
   respCol,
-  weights,
+  weights = NULL,
   contrasts,
-  size = NULL,
   family,
   se = NULL,
   call = NULL,
@@ -48,11 +47,9 @@ mkTMBStruc(
 
 \item{respCol}{response column}
 
-\item{weights}{weights, as in \code{glm}. Not automatically scaled to have sum 1.}
+\item{weights}{model weights (for binomial-type models, used as size/number of trials)}
 
 \item{contrasts}{an optional list, e.g., \code{list(fac1="contr.sum")}. See the \code{contrasts.arg} of \code{\link{model.matrix.default}}.}
-
-\item{size}{number of trials in binomial and betabinomial families}
 
 \item{family}{family object}
 

--- a/glmmTMB/man/simulate_new.Rd
+++ b/glmmTMB/man/simulate_new.Rd
@@ -8,6 +8,7 @@ simulate_new(
   object,
   nsim = 1,
   seed = NULL,
+  family = gaussian,
   newdata,
   newparams,
   ...,
@@ -22,6 +23,8 @@ takes a fitted model object)}
 \item{nsim}{number of simulations}
 
 \item{seed}{random-number seed}
+
+\item{family}{a family function, a character string naming a family function, or the result of a call to a family function (variance/link function) information. See \code{\link{family}} for a generic discussion of families or \code{\link{family_glmmTMB}} for details of \code{glmmTMB}-specific families.}
 
 \item{newdata}{a data frame containing all variables listed in the formula,
 \emph{including} the response variable (which needs to fall within

--- a/glmmTMB/man/startParams.Rd
+++ b/glmmTMB/man/startParams.Rd
@@ -33,7 +33,7 @@ startParams(
 
 \item{yobs}{observed y}
 
-\item{weights}{weights, as in \code{glm}. Not automatically scaled to have sum 1.}
+\item{weights}{model weights (for binomial-type models, used as size/number of trials)}
 
 \item{size}{number of trials in binomial and betabinomial families}
 

--- a/glmmTMB/tests/testthat/test-methods.R
+++ b/glmmTMB/tests/testthat/test-methods.R
@@ -626,6 +626,19 @@ test_that("de novo simulation", {
                       c(2.67396350948461, 5.55246185541914))
 })
 
+test_that("de novo simulation with binomial N>1", {
+    dd <- data.frame(x = 1:10)
+    ss <- simulate_new(~ x,
+                 seed = 101,
+                 family = binomial,
+                 weights = rep(10, 10),
+                 newdata = dd,
+                 newparams = list(beta = c(-0.5, 0.1), betad = 0))
+    expect_equal(head(ss[[1]], 2),
+                      c(3, 2))
+})
+
+
 test_that("weighted residuals", {
     set.seed(101)
     data("cbpp", package = "lme4")


### PR DESCRIPTION
these commits change the handling of `weights`/`size` slightly; partly cleanup, partly making it easier to use `simulate_new()` to simulate binomial-type data with N>1