### PR TITLE
Check neg binom vals

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -1241,6 +1241,11 @@ glmmTMB <- function(
     ##  and then only to check whether it's NULL or not ...
     etastart <- mustart <- NULL
 
+    ## hack initialization method to flag negative values
+    if (family$family == "binomial") {
+        family$initialize <- our_binom_initialize(family$family)
+    }
+    
     if (!is.null(family$initialize)) {
         local(eval(family$initialize))  ## 'local' so it checks but doesn't modify 'y' and 'weights'
     }

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -682,3 +682,17 @@ get_family <- function(family) {
     }
     return(family)
 }
+
+
+## add negative-value check to binomial initialization method
+our_binom_initialize <- function(family) {
+    newtest <- substitute(
+        ## added test for glmmTMB
+        if (any(y<0)) {
+            stop(sprintf('negative values not allowed for the %s family', FAMILY))
+        }
+      , list(FAMILY=family))
+    b0 <- binomial()$initialize
+    b0[[length(b0)+1]] <- newtest
+    return(b0)
+}

--- a/glmmTMB/src/glmmTMB.cpp
+++ b/glmmTMB/src/glmmTMB.cpp
@@ -811,7 +811,9 @@ Type objective_function<Type>::operator() ()
         s3 = sqrt(s1);          //log-scale sd
 	tmp_loglik = zt_lik_zero(yobs(i),
 			 dnorm(log(yobs(i)), s2, s3, true) - log(yobs(i)));
-	SIMULATE{yobs(i) = exp(rnorm(s2, s3));}  // untested
+	SIMULATE{
+	  yobs(i) = exp(rnorm(s2, s3));
+	}  // untested
         break;
       case t_family:
         s1 = (yobs(i) - mu(i))/phi(i);

--- a/glmmTMB/tests/testthat/test-basics.R
+++ b/glmmTMB/tests/testthat/test-basics.R
@@ -2,8 +2,10 @@
 stopifnot(require("testthat"),
           require("glmmTMB"))
 
+## drop (unimportant) info that may not match across versions
 drop_version <- function(obj) {
     obj$modelInfo$packageVersion <- NULL
+    obj$modelInfo$family$initialize <- NULL  ## updated initialization expressions
     obj
 }
 

--- a/glmmTMB/tests/testthat/test-families.R
+++ b/glmmTMB/tests/testthat/test-families.R
@@ -15,7 +15,6 @@ simfun0 <- function(beta=c(2,1),
     return(data.frame(x,f,mu))
 }
 
-context("alternative binomial specifications")
 test_that("binomial", {
     load(system.file("testdata","radinger_dat.RData",package="lme4"))
     radinger_dat <<- radinger_dat ## global assignment for testthat
@@ -62,29 +61,44 @@ test_that("binomial", {
     expect_warning( glmmTMB(prop~1, family=binomial()) )   ## Warning as glm
     x <- c(1, 2, 3)        ## weights=1 => x > weights !
     expect_error  ( glmmTMB(x~1, family=binomial(),
-                    data = data.frame(x)))      ## Error as glm
+                            data = data.frame(x)))      ## Error as glm
+
 })
 
-context("non-integer count warnings")
-test_that("count distributions", {
-    dd <- data.frame(y=c(0.5,1,1,1))
-    for (f in c("binomial","betabinomial","poisson",
-                "genpois",
-                ## "compois", ## fails anyway ...
+## check for negative values
+test_that("detect negative values in two-column binomial response", {
+    x <- matrix(c(-1, 1, 2, 2, 3, 4), nrow = 3)
+    expect_error(glmmTMB(x~1, family=binomial(), data = NULL),
+                 "negative values not allowed")
+})
+
+count_dists <-c("poisson", "genpois", "compois",
                 "truncated_genpois",
-                # "truncated_compois",
-                "nbinom1",
-                "nbinom2"
-                # why do these truncated cases fail?
-                ##, "truncated_nbinom1",
-                ##"truncated_nbinom2"
-                )) {
-        expect_warning(m <- glmmTMB(y~1,data=dd,family=f),
-                       "non-integer")
+                "nbinom1", "nbinom2",
+                "truncated_nbinom1",
+                "truncated_nbinom2"
+                )
+
+binom_dists <- c("binomial", "betabinomial")
+
+test_that("count distributions", {
+    dd <- data.frame(y=c(0.5, rep(1:4, c(9, 2, 2, 2))))
+    for (f in count_dists) {
+        expect_warning(glmmTMB(y~1, data=dd, family=f), "non-integer")
     }
 })
 
-context("fitting exotic families")
+test_that("binom-type distributions", {
+    dd <- data.frame(y=c(0.5, rep(1:4, c(9, 2, 2, 2)))/10)
+    for (f in binom_dists) {
+        expect_warning(glmmTMB(y~1,
+                               weights = rep(10, nrow(dd)),
+                               data=dd, family=f), "non-integer")
+    }
+})
+
+
+
 test_that("beta", {
   skip_on_cran()
     set.seed(101)
@@ -333,7 +347,6 @@ test_that("truncated_genpois",{
 })
 
 
-context("trunc compois")
 ##Compois
 test_that("truncated_compois",{
     skip_on_cran()
@@ -345,7 +358,6 @@ test_that("truncated_compois",{
 	expect_equal(predict(tcmp1,type="response")[1:2], c(19.4, 7.3), tolerance = 1e-6)
 })
 
-context("compois")
 test_that("compois", {
     skip_on_cran()
 #	cmpdat <<- data.frame(f=factor(rep(c('a','b'), 10)),
@@ -356,7 +368,6 @@ test_that("compois", {
 	expect_equal(predict(cmp1,type="response")[1:2], c(19.4, 7.3), tolerance = 1e-6)
 })
 
-context("genpois")
 test_that("genpois", {
     skip_on_cran()
 	gendat <<- data.frame(y=c(11,10,9,10,9,8,11,7,9,9,9,8,11,10,11,9,10,7,13,9))
@@ -365,7 +376,6 @@ test_that("genpois", {
 	expect_equal(sigma(gen1), 0.235309, tolerance = 1e-6)
 })
 
-context("tweedie")
 test_that("tweedie", {
     skip_on_cran()
     ## Boiled down tweedie:::rtweedie :

--- a/misc/neg_binom_ex.R
+++ b/misc/neg_binom_ex.R
@@ -1,0 +1,27 @@
+## from https://github.com/glmmTMB/glmmTMB/issues/988
+
+library(glmmTMB)
+set.seed(101); dd <- data.frame(x = 1:10)
+m1 <- glmmTMB(cbind(x, 10-x) ~ 1, family = betabinomial, data = dd)
+sessionInfo()
+
+dd2 <- rbind(dd, data.frame(x=-1))
+update(m1, data = dd2)  ## NOT detected
+update(m1, data = dd2, family = binomial)  ## gives weird/infinite answers
+
+try(glm(cbind(x, 10-x) ~ 1, family = binomial, data = dd2))
+
+b0 <- binomial()$initialize
+
+our_binomInitialize <- function(family) {
+    substitute({
+        if (any(y<0)) {
+            stop(sprintf('negative values not allowed in %s responses', FAMILY))
+        }
+    }, list(FAMILY=family))
+}
+
+b_new <- betabinomial()
+b_new$initialize <- our_binomInitialize("betabinomial")
+
+update(m1, data = dd2, family = b_new)

--- a/misc/neg_binom_ex.R
+++ b/misc/neg_binom_ex.R
@@ -11,17 +11,21 @@ update(m1, data = dd2, family = binomial)  ## gives weird/infinite answers
 
 try(glm(cbind(x, 10-x) ~ 1, family = binomial, data = dd2))
 
-b0 <- binomial()$initialize
+
 
 our_binomInitialize <- function(family) {
-    substitute({
+    newtest <- substitute(
+        ## added test for glmmTMB
         if (any(y<0)) {
             stop(sprintf('negative values not allowed in %s responses', FAMILY))
         }
-    }, list(FAMILY=family))
+      , list(FAMILY=family))
+    b0 <- binomial()$initialize
+    b0[[3]] <- newtest
+    return(b0)
 }
 
 b_new <- betabinomial()
 b_new$initialize <- our_binomInitialize("betabinomial")
 
-update(m1, data = dd2, family = b_new)
+try(update(m1, data = dd2, family = b_new))


### PR DESCRIPTION
The initial inspiration for this was to fix the problem in #988 (which was ultimately about the user having negative values in a two-column binomial response variable, but getting a confusing error). This also adds improved checking for negative or non-integer response values in count and binomial-type families.