### PR TITLE
Simulate new init fix

### DIFF
--- a/glmmTMB/DESCRIPTION
+++ b/glmmTMB/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: glmmTMB
 Title: Generalized Linear Mixed Models using Template Model Builder
-Version: 1.1.9
+Version: 1.1.9-9000
 Authors@R: c(person("Mollie","Brooks",
 		comment=c(ORCID="0000-0001-6963-8326"),
 		role = c("aut", "cre"),

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -654,8 +654,10 @@ simulate_new <- function(object,
     form <- object
     form[[3]] <- form[[2]]
     form[[2]] <- quote(..y)
-    ## insert a legal value: 1.0 is OK as long as family != "beta_family"
-    newdata[["..y"]] <- if (family$family == "beta_family") 0.5 else 1.0
+    ## insert a legal value: 1.0 is OK as long as family != "beta"
+    ## (note the family *function* is 'beta_family' but the internal
+    ##  $family value is 'beta')
+    newdata[["..y"]] <- if (family$family == "beta") 0.5 else 1.0
     r1 <- glmmTMB(form,
                   data = newdata,
                   family = family,

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -4,7 +4,15 @@
 \title{glmmTMB News}
 \encoding{UTF-8}
 
-\section{CHANGES IN VERSION 1.1.9}{
+\section{CHANGES IN VERSION 1.1.9-9000}{
+  \subsection{BUG FIXES}{
+    \itemize{
+      \item fixed bug in \code{simulate_new} for \code{family = "beta_family")
+    }
+  } % bug fixes
+} % 1.1.9-9000
+  
+\section{CHANGES IN VERSION 1.1.9 (2024-03-20)}{
   \subsection{USER-VISIBLE CHANGES}{
     \itemize{
       \item the underlying parameterization of the dispersion for

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -52,7 +52,7 @@
       attributes (GH #977)
     } % itemize
   } % bug fixes
-} % 1.1.8-9000
+} % 1.1.9
 
 \section{CHANGES IN VERSION 1.1.8 (2023-10-07)}{
   \subsection{NEW FEATURES}{

--- a/glmmTMB/tests/testthat/test-methods.R
+++ b/glmmTMB/tests/testthat/test-methods.R
@@ -660,6 +660,19 @@ test_that("de novo simulation error checking", {
                  "unmatched parameter names: junk")
 })
 
+test_that("good simulate_new response values for beta", {
+    data("sleepstudy", package = "lme4")
+    ss <- simulate_new(
+        ~ Days + (Days | Subject),
+        newdata = sleepstudy,
+        newparams = list(beta = c(-1, 0.1),
+                         theta = c(-1, -1, 0),
+                         betad = 10),
+        family = "beta_family",
+        seed = 101)
+    expect_equal(head(ss[[1]], 3),
+                 c(0.246573218210702, 0.309824346705961, 0.367484246522732))
+})
 
 test_that("weighted residuals", {
     set.seed(101)


### PR DESCRIPTION
when setting dummy response values for `simulate_new` (which must be legal values for the specified family), was testing for `family$family == "beta_family"` rather than `family$family == "beta"`