### PR TITLE
Increase minimal R version

### DIFF
--- a/glmmTMB/DESCRIPTION
+++ b/glmmTMB/DESCRIPTION
@@ -42,7 +42,7 @@ Description: Fit linear and generalized linear mixed models with various
     out using the Laplace approximation. Gradients are calculated using automatic
     differentiation.
 License: AGPL-3
-Depends: R (>= 3.6.0)
+Depends: R (>= 4.1.0)
 Imports:
     methods,
     TMB (>= 1.9.0),


### PR DESCRIPTION
Dear glmmTMB team,

First thank you for developing and maintaining this package.

I would like to submit a change regarding the current minimal version of R required for installing the package. It is `>=3.6.0` ([source](https://github.com/glmmTMB/glmmTMB/blob/99dffd69bb371307505c7eb978c1ffc499c7d507/glmmTMB/DESCRIPTION#L45)). This leads to an error after compilation using R 3.6.0:
```R
"/usr/lib/R/bin/Rscript" -e "cat(as.character(packageVersion('TMB')), '\n', sep="", file='../inst/TMB-version')"
"/usr/lib/R/bin/Rscript" -e "cat(as.character(packageVersion('Matrix')), '\n', sep="", file='../inst/Matrix-version')"
installing to /home/XX/.R-libs/3.6.3/00LOCK-glmmTMB/00new/glmmTMB/libs
** R
Error in parse(outFile) :
  /tmp/RtmpH6yjZS/R.INSTALL67b7702b1f28/glmmTMB/R/priors.R:95:49: unexpected '>'
94:                                 if (length(cc) == 0) return(integer(0))
95:                                 cc <- c(1, cc) |>
                                                    ^
ERROR: unable to collate and parse R files for package ‘glmmTMB’
* removing ‘/home/XX/.R-libs/3.6.3/glmmTMB’
```

Pipe operators (`|>`) are present in several files of the package (like [here](https://github.com/glmmTMB/glmmTMB/blob/99dffd69bb371307505c7eb978c1ffc499c7d507/glmmTMB/vignettes/priors.rmd#L100)). Native pipe operator has been implemented in R only in version 4.1.0. So this should be the minimal version required for installation.

I tested the proposed change with R 4.1.3 and it worked as expected. Installation with R version lower than 4.1.0 will generate an expected error message regarding R version.