### PR TITLE
fix/improve get_cor, put_cor

### DIFF
--- a/glmmTMB/DESCRIPTION
+++ b/glmmTMB/DESCRIPTION
@@ -51,8 +51,7 @@ Imports:
     nlme,
     numDeriv,
     mgcv,
-    reformulas (>= 0.2.0),
-    fastmatrix
+    reformulas (>= 0.2.0)
 LinkingTo: TMB, RcppEigen
 Suggests:
     knitr,

--- a/glmmTMB/DESCRIPTION
+++ b/glmmTMB/DESCRIPTION
@@ -51,7 +51,8 @@ Imports:
     nlme,
     numDeriv,
     mgcv,
-    reformulas (>= 0.2.0)
+    reformulas (>= 0.2.0),
+    fastmatrix
 LinkingTo: TMB, RcppEigen
 Suggests:
     knitr,

--- a/glmmTMB/R/enum.R
+++ b/glmmTMB/R/enum.R
@@ -61,7 +61,7 @@
 .valid_vprior <- c(
   beta = 0,
   betazi = 1,
-  betad = 2,
+  betadisp = 2,
   theta = 10,
   thetazi = 20,
   psi = 30

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -44,40 +44,60 @@ parallel_default <- function(parallel=c("no","multicore","snow"),ncpus=1) {
     return(list(parallel=parallel,do_parallel=do_parallel))
 }
 
+## from length of (strictly) lower triangle, compute dimension of matrix
+get_matdim <- function(ntri) {
+    as.integer(round(0.5 * (1 + sqrt(1 + 8 * ntri))))
+}
+
 ##' translate vector of correlation parameters to correlation values
 ##' @param theta vector of internal correlation parameters (elements of scaled Cholesky factor, in \emph{row-major} order)
+##' @param return_val return a vector of correlation values from the lower triangle ("vec"), or the full correlation matrix ("mat")? 
 ##' @return a vector of correlation values (\code{get_cor}) or glmmTMB scaled-correlation parameters (\code{put_cor})
 ##' @details These functions follow the definition at \url{http://kaskr.github.io/adcomp/classdensity_1_1UNSTRUCTURED__CORR__t.html}:
 ##' if \eqn{L} is the lower-triangular matrix with 1 on the diagonal and the correlation parameters in the lower triangle, then the correlation matrix is defined as \eqn{\Sigma = D^{-1/2} L L^\top D^{-1/2}}{Sigma = sqrt(D) L L' sqrt(D)}, where \eqn{D = \textrm{diag}(L L^\top)}{D = diag(L L')}. For a single correlation parameter \eqn{\theta_0}{theta0}, this works out to \eqn{\rho = \theta_0/\sqrt{1+\theta_0^2}}{rho = theta0/sqrt(1+theta0^2)}. The \code{get_cor} function returns the elements of the lower triangle of the correlation matrix, in column-major order.
 ##' @examples
 ##' th0 <- 0.5
 ##' stopifnot(all.equal(get_cor(th0),th0/sqrt(1+th0^2)))
-##' get_cor(c(0.5,0.2,0.5))
-##' C <- matrix(c(1,  0.2,  0.1,
-##'              0.2,  1, -0.2,
-##'              0.1,-0.2,   1),
-##'            3, 3)
-##' ## test: round-trip (almostl results in lower triangle only)
-##' stopifnot(all.equal(get_cor(put_cor(C)),
-##'                    C[lower.tri(C)]))
+##' set.seed(101)
+##' C <- get_cor(rnorm(21), return_val = "mat")
+##' ## test: round-trip
+##' stopifnot(all.equal(get_cor(put_cor(C), return_val = "mat"), C))
 ##' @export
-get_cor <- function(theta) {
-  n <- as.integer(round(0.5 * (1 + sqrt(1 + 8 * length(theta)))))
-  R <- diag(n)
-  R[upper.tri(R)] <- theta
-  R[] <- crossprod(R) # R <- t(R) %*% R
-  scale <- 1 / sqrt(diag(R))
-  R[] <- scale * R * rep(scale, each = n) # R <- cov2cor(R)
-  R[lower.tri(R)]
+get_cor <- function(theta, return_val = c("vec", "mat")) {
+    return_val <- match.arg(return_val)
+    n <-  get_matdim(length(theta))
+    R <- diag(n)
+    R[upper.tri(R)] <- theta
+    R[] <- crossprod(R) # R <- t(R) %*% R
+    scale <- 1 / sqrt(diag(R))
+    R[] <- scale * R * rep(scale, each = n) # R <- cov2cor(R)
+    if (return_val == "mat") return(R)
+    return(R[lower.tri(R)])
 }
 
 ##' @rdname get_cor
 ##' @param C a correlation matrix
+##' @param input_val input a vector of correlation values from the lower triangle ("vec"), or the full correlation matrix ("mat")? 
 ##' @export
-put_cor <- function(C) {
-    cc <- chol(C)
-    cc2 <- t(cc %*% diag(1/diag(cc)))
-    cc2[lower.tri(cc2)]
+put_cor <- function(C, input_val = c("mat", "vec")) {
+    ## need LDL composition here, induces dependence on fastmatrix package
+    ## to weaken the dependence we could
+    ## (1) do if (requireNamespace()) stuff to make this Suggests:
+    ## (2) steal code from 
+    ##  https://github.com/faosorios/fastmatrix/blob/master/pkg/src/ldl_decomp.f
+    ##  https://github.com/faosorios/fastmatrix/blob/master/pkg/R/ldl.R
+    ## (or write code calling Lapack ssptrf)
+    input_val <- match.arg(input_val)
+    if (input_val == "vec") {
+        ## construct matrix
+        M <- diag(get_matdim(length(C)))
+        M[lower.tri(M)] <- C
+        M[upper.tri(M)] <- t(M)[upper.tri(M)]
+        C <- M
+    }
+    scale <- sqrt(fastmatrix::ldl(as.matrix(C))$d)
+    cc2 <- chol(C) %*% diag(1/scale)
+    cc2[upper.tri(cc2)]
 }
 
 hasRandom <- function(x) {

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -80,13 +80,6 @@ get_cor <- function(theta, return_val = c("vec", "mat")) {
 ##' @param input_val input a vector of correlation values from the lower triangle ("vec"), or the full correlation matrix ("mat")? 
 ##' @export
 put_cor <- function(C, input_val = c("mat", "vec")) {
-    ## need LDL composition here, induces dependence on fastmatrix package
-    ## to weaken the dependence we could
-    ## (1) do if (requireNamespace()) stuff to make this Suggests:
-    ## (2) steal code from 
-    ##  https://github.com/faosorios/fastmatrix/blob/master/pkg/src/ldl_decomp.f
-    ##  https://github.com/faosorios/fastmatrix/blob/master/pkg/R/ldl.R
-    ## (or write code calling Lapack ssptrf)
     input_val <- match.arg(input_val)
     if (input_val == "vec") {
         ## construct matrix
@@ -95,8 +88,9 @@ put_cor <- function(C, input_val = c("mat", "vec")) {
         M[upper.tri(M)] <- t(M)[upper.tri(M)]
         C <- M
     }
-    scale <- sqrt(fastmatrix::ldl(as.matrix(C))$d)
-    cc2 <- chol(C) %*% diag(1/scale)
+    cc2 <- chol(C)
+    scale <- diag(cc2)
+    cc2 <- cc2 %*% diag(1/scale)
     cc2[upper.tri(cc2)]
 }
 

--- a/glmmTMB/man/get_cor.Rd
+++ b/glmmTMB/man/get_cor.Rd
@@ -5,14 +5,18 @@
 \alias{put_cor}
 \title{translate vector of correlation parameters to correlation values}
 \usage{
-get_cor(theta)
+get_cor(theta, return_val = c("vec", "mat"))
 
-put_cor(C)
+put_cor(C, input_val = c("mat", "vec"))
 }
 \arguments{
 \item{theta}{vector of internal correlation parameters (elements of scaled Cholesky factor, in \emph{row-major} order)}
 
+\item{return_val}{return a vector of correlation values from the lower triangle ("vec"), or the full correlation matrix ("mat")?}
+
 \item{C}{a correlation matrix}
+
+\item{input_val}{input a vector of correlation values from the lower triangle ("vec"), or the full correlation matrix ("mat")?}
 }
 \value{
 a vector of correlation values (\code{get_cor}) or glmmTMB scaled-correlation parameters (\code{put_cor})
@@ -27,12 +31,8 @@ if \eqn{L} is the lower-triangular matrix with 1 on the diagonal and the correla
 \examples{
 th0 <- 0.5
 stopifnot(all.equal(get_cor(th0),th0/sqrt(1+th0^2)))
-get_cor(c(0.5,0.2,0.5))
-C <- matrix(c(1,  0.2,  0.1,
-             0.2,  1, -0.2,
-             0.1,-0.2,   1),
-           3, 3)
-## test: round-trip (almostl results in lower triangle only)
-stopifnot(all.equal(get_cor(put_cor(C)),
-                   C[lower.tri(C)]))
+set.seed(101)
+C <- get_cor(rnorm(21), return_val = "mat")
+## test: round-trip
+stopifnot(all.equal(get_cor(put_cor(C), return_val = "mat"), C))
 }

--- a/glmmTMB/tests/testthat/test-utils.R
+++ b/glmmTMB/tests/testthat/test-utils.R
@@ -40,3 +40,21 @@ test_that("get_cor", {
   y1 <- get_cor(theta)
   expect_equal(x, y1)
 })
+
+test_that("put_cor", {
+    round_trip <- function(C) {
+        expect_equal(get_cor(put_cor(C), return_val = "mat"), C)
+    }
+    set.seed(101)
+    for (n in 2:10) {
+        for (i in 1:10) {
+            round_trip(get_cor(rnorm(n*(n-1)/2), return_val = "mat"))
+        }
+    }
+})
+
+##' th0 <- 0.5
+##' stopifnot(all.equal(get_cor(th0),th0/sqrt(1+th0^2)))
+##' set.seed(101)
+##' C <- get_cor(rnorm(21), return_val = "mat")
+##' ## test: round-trip

--- a/glmmTMB/tests/testthat/test-utils.R
+++ b/glmmTMB/tests/testthat/test-utils.R
@@ -52,9 +52,3 @@ test_that("put_cor", {
         }
     }
 })
-
-##' th0 <- 0.5
-##' stopifnot(all.equal(get_cor(th0),th0/sqrt(1+th0^2)))
-##' set.seed(101)
-##' C <- get_cor(rnorm(21), return_val = "mat")
-##' ## test: round-trip

--- a/glmmTMB/vignettes/covstruct.rmd
+++ b/glmmTMB/vignettes/covstruct.rmd
@@ -543,7 +543,7 @@ for variance parameters) and their order.
 ### Unstructured
 
 For an unstructured matrix of size `n`, parameters `1:n` represent the log-standard deviations while the remaining `n(n-1)/2` (i.e. `(n+1):(n:(n*(n+1)/2))`) are the elements of the *scaled* Cholesky factor of the correlation matrix, filled in row-wise order (see [TMB documentation](http://kaskr.github.io/adcomp/classdensity_1_1UNSTRUCTURED__CORR__t.html)). In particular, if $L$ is the lower-triangular matrix with 1 on the diagonal and the correlation parameters in the lower triangle, then the correlation matrix is defined as $\Sigma = D^{-1/2} L L^\top D^{-1/2}$, where $D = \textrm{diag}(L L^\top)$. For a single correlation parameter $\theta_0$, this works out to $\rho = \theta_0/\sqrt{1+\theta_0^2}$
-(with inverse $\theta_0 =  \rho/\sqrt(1-\rho^2)$.
+(with inverse $\theta_0 =  \rho/\sqrt(1-\rho^2)$. You can use the utility functions `get_cor()` (transform a `theta` vector into the upper triangular [rowwise] elements of a correlation matrix, or the full correlation matrix) and `put_cor()` (translate a correlation matrix, or the values from the lower triangle, into a `theta` vector) to perform these transformations.
 
 (See calculations [here](https://github.com/glmmTMB/glmmTMB/blob/master/misc/glmmTMB_corcalcs.ipynb).)
 

--- a/glmmTMB/vignettes/sim.rmd
+++ b/glmmTMB/vignettes/sim.rmd
@@ -103,12 +103,13 @@ The simulated data have about the right variability, but in contrast to the real
 
 The next example will be more complex, getting into the nuts and bolts of how to translate random effects covariances into the terms that `glmmTMB` expects.
 
-The hardest piece is probably translating correlation parameters. The "covariance structures" vignette has more details on how correlation matrices are parameterized, and the `put_cor()` function is a general translator, but for the specific case of 2x2 correlation matrices (i.e. with a single correlation parameter), a correlation $\rho$ corresponds to a `glmmTMB` parameter of $\rho/\sqrt{1-\rho^2}$. Here's a utility function:
+The hardest piece is probably translating correlation parameters. The "covariance structures" vignette has more details on how correlation matrices are parameterized, and the `put_cor()` function is a general translator from a specified correlation matrix (or its lower triangular elements) to the appropriate set of `theta` parameters. For the specific case of 2x2 correlation matrices (i.e. with a single correlation parameter), a correlation $\rho$ corresponds to a `glmmTMB` parameter of $\rho/\sqrt{1-\rho^2}$. Here's a utility function:
 
 ```{r rho-to-theta}
 rho_to_theta <- function(rho) rho/sqrt(1-rho^2)
 ## tests
 stopifnot(all.equal(get_cor(rho_to_theta(-0.2)), -0.2))
+## equivalent to general function
 stopifnot(all.equal(rho_to_theta(-0.2), put_cor(-0.2, input_val = "vec")))
 ```
 

--- a/glmmTMB/vignettes/sim.rmd
+++ b/glmmTMB/vignettes/sim.rmd
@@ -109,8 +109,9 @@ The hardest piece is probably translating correlation parameters. The "covarianc
 rho_to_theta <- function(rho) rho/sqrt(1-rho^2)
 ## tests
 stopifnot(all.equal(get_cor(rho_to_theta(-0.2)), -0.2))
-stopifnot(all.equal(rho_to_theta(-0.2), put_cor(matrix(c(1,-0.2,-0.2,1), 2))))
+stopifnot(all.equal(rho_to_theta(-0.2), put_cor(-0.2, input_val = "vec")))
 ```
+
 Setting up metadata/covariates (tools in the `faux` package may also be useful for this):
 
 ```{r sim1}


### PR DESCRIPTION
utilities for translating between `theta` and unstructured correlation matrices (bidirectional); the corr-to-theta direction (`put_cor`) was buggy. I needed an LDL decomposition, so this now depends on the fastmatrix package (which has no further dependencies). If we wanted to avoid that there are some suggestions in comments in the code ...

Also highlighted these functions better in the covstruct and sim vignettes.