### PR TITLE
modify parallel to allow autopar

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -3,11 +3,15 @@ openmp_debug <- function() {
     getOption("glmmTMB_openmp_debug", FALSE)
 }
 
-## glmmTMB openmp controller copied from TMB (Windows needs it).
-openmp <- function (n = NULL) {
-    if (openmp_debug() && !is.null(n)) {
-        cat("setting OpenMP threads to ", n, "\n")
-    }
+## glmmTMB openmp controller copied from TMB (Windows needs it),
+## and it also lets us have more control of debug tracing etc.
+openmp <- function (n = NULL, autopar = NULL) {
+    report <-  (openmp_debug() && (!is.null(n) || !is.null(autopar)))
+    ## use deparse() etc. to handle cat(NULL), possible attributes/naming
+    prefix <- if (is.null(n) && is.null(autopar)) "current OpenMP settings:" else "setting OpenMP:"
+    if (report) cat(prefix, " threads = ", deparse(unname(c(n))),
+                    ", autopar = ", deparse(autopar), "\n",
+                    sep = "")
     ## FIXME: redundant with integer-setting within omp_num_threads C++ def in utils.cpp
     null_arg <- is.null(n)
     if (!null_arg) n <- as.integer(n)
@@ -17,7 +21,8 @@ openmp <- function (n = NULL) {
       w <- options(warn = -1)
       on.exit(options(warn = w[["warn"]]))
     }
-    TMB::openmp(n, DLL="glmmTMB")
+    tt <- TMB::openmp(n, autopar = autopar, DLL="glmmTMB")
+    return(list(n = c(tt), autopar = attr(tt, "autopar")))
 }
 
 ##' Change starting parameters, either by residual method or by user input (start)
@@ -1360,13 +1365,18 @@ glmmTMB <- function(
 ##'                  robustness when a model has many fixed effects
 ##' @param collect   (logical) Experimental option to improve speed by
 ##'                  recognizing duplicated observations.
-##' @param parallel  (integer) Set number of OpenMP threads to evaluate
-##' the negative log-likelihood in parallel. The default is to evaluate
-##' models serially (i.e. single-threaded); users can set a default value
-##' for an R session via \code{options(glmmTMB.cores=<value>)}. At present
-##' reduced-rank models (i.e., a covariance structure using \code{rr(...)})
-##' cannot be fitted in parallel; the number of threads will be automatically
+##' @param parallel  (named list with an integer value \code{n} and a logical value \code{autopar},
+##' e.g. \code{list(n=4L, autopar=TRUE)}) Set number of OpenMP threads to evaluate
+##' the negative log-likelihood in parallel, and determine whether to use auto-parallelization
+##' (see \code{\link[TMB]{openmp}}). The default is to evaluate
+##' models serially (i.e. single-threaded); users can set default values
+##' for an R session via \code{options(glmmTMB.cores=<value>, glmmTMB.autopar=<value>)}.
+##' An integer number of cores (only) can be passed instead of a list, in which case the default or
+##' previously set value of \code{autopar} will be used.
+##' At present reduced-rank models (i.e., a covariance structure using \code{rr(...)})
+##' cannot be fitted in parallel unless \code{autopar=TRUE}; the number of threads will be automatically
 ##' set to 1, with a warning if this overrides the user-specified value.
+##' To trace OpenMP settings, use \code{options(glmmTMB_openmp_debug = TRUE)}.
 ##' @param optimizer Function to use in model fitting. See \code{Details} for required properties of this function.
 ##' @param eigval_check Check eigenvalues of variance-covariance matrix? (This test may be very slow for models with large numbers of fixed-effect parameters.)
 ##' @param zerodisp_val value of the dispersion parameter when \code{dispformula=~0} is specified
@@ -1416,7 +1426,7 @@ glmmTMBControl <- function(optCtrl=NULL,
                            optimizer=nlminb,
                            profile=FALSE,
                            collect=FALSE,
-                           parallel = getOption("glmmTMB.cores", 1L),
+                           parallel = list(n = getOption("glmmTMB.cores", 1L), autopar = getOption("glmmTMB.autopar", NULL)),
                            eigval_check = TRUE,
                            ## want variance to be sqrt(eps), so sd = eps^(1/4)
                            zerodisp_val=log(.Machine$double.eps)/4,
@@ -1429,10 +1439,14 @@ glmmTMBControl <- function(optCtrl=NULL,
     }
     ## Make sure that we specify at least one thread
     if (!is.null(parallel)) {
-        if (is.na(parallel) || parallel < 1) {
+        if (length(parallel) == 1 && is.numeric(parallel)) {
+            parallel <- list(n = parallel, autopar = getOption("glmmTMB.autopar", NULL))
+        }
+        if (is.null(names(parallel))) stop(sQuote("parallel"), "list passed to glmmTMBControl() must be named")
+        if (is.na(parallel$n) || parallel$n < 1) {
             stop("Number of parallel threads must be a numeric >= 1")
         }
-        parallel <- as.integer(parallel)
+        parallel$n <- as.integer(parallel$n)
     }
 
     rank_check <- match.arg(rank_check)
@@ -1659,19 +1673,19 @@ fitTMB <- function(TMBStruc, doOptim = TRUE) {
     if ((has_any_rr(TMBStruc$condReStruc) ||
         has_any_rr(TMBStruc$ziReStruc) ||
     		 has_any_rr(TMBStruc$dispReStruc)) &&
-        TMBStruc$control$parallel > 1) {
-        warning("rr() not compatible with parallel execution: setting ncores to 1")
-        TMBStruc$control$parallel <- 1
+        TMBStruc$control$parallel$n > 1 && !isTRUE(TMBStruc$control$parallel$autopar)) {
+        warning("rr() not compatible with parallel execution unless parallel$autopar=TRUE: setting ncores to 1")
+        TMBStruc$control$parallel$n <- 1
     }
 
     ## Assign OpenMP threads
     n_orig <- openmp(NULL)
     ## Only proceed farther if OpenMP *is* supported ...
-    if (n_orig > 0) {
-        openmp(n = control$parallel)
+    if (n_orig$n > 0) {
+        with(control$parallel, openmp(n = n, autopar = autopar))
         on.exit({
-          openmp(n = n_orig)
-          })
+            do.call(openmp, n_orig)
+        })
     }
 
     if (control $ collect) {

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -1443,12 +1443,17 @@ glmmTMBControl <- function(optCtrl=NULL,
             parallel <- list(n = parallel, autopar = getOption("glmmTMB.autopar", NULL))
         }
         if (is.null(names(parallel))) stop(sQuote("parallel"), "list passed to glmmTMBControl() must be named")
-        if (is.na(parallel$n) || parallel$n < 1) {
-            stop("Number of parallel threads must be a numeric >= 1")
+        ## FIXME: more elegant way to handle possible parallel arg cases (e.g. n only, autopar only)
+        if (length(parallel$n) == 0) {
+            parallel$n <- getOption("glmmTMB.cores", 1L)
+        } else {
+            if (is.na(parallel$n) || parallel$n < 1) {
+                stop("Number of parallel threads must be a numeric >= 1")
+            }
+            parallel$n <- as.integer(parallel$n)
         }
-        parallel$n <- as.integer(parallel$n)
     }
-
+    
     rank_check <- match.arg(rank_check)
     conv_check <- match.arg(conv_check)
 

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -1106,8 +1106,8 @@ confint.glmmTMB <- function (object, parm = NULL, level = 0.95,
         parallel <- plist$parallel
         do_parallel <- plist$do_parallel
         FUN <- function(n) {
-          n_orig <- openmp(n = object$modelInfo$parallel)
-          on.exit(openmp(n_orig))
+          n_orig <- do.call(openmp, object$modelInfo$parallel)
+          on.exit(do.call(openmp, n_orig))
           TMB::tmbroot(obj=object$obj, name=n, target=0.5*qchisq(level,df=1),
                        ...)
         }

--- a/glmmTMB/R/profile.R
+++ b/glmmTMB/R/profile.R
@@ -117,8 +117,8 @@ profile.glmmTMB <- function(fitted,
         function(p,s) {
             if (trace>0) cat("parameter",p,"\n")
             n_orig <- openmp(NULL)
-            openmp(n = fitted$modelInfo$parallel)
-            on.exit(openmp(n_orig))
+            do.call(openmp, fitted$modelInfo$parallel)
+            on.exit(do.call(openmp, n_orig))
             return(tmbprofile(fitted$obj,
                               name=p,
                               h=s/4,

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -414,14 +414,6 @@ up2date <- function(oldfit, update_gauss_disp = FALSE) {
           }
       }
 
-      ## changed format of 'parallel' control to add autopar info
-      if (length(p <- oldfit$modelInfo$parallel) == 1) {
-          if (!(is.null(p) || is.numeric(p))) {
-              stop("oldfit$modelInfo$parallel has an unexpected value")
-          }
-          oldfit$modelInfo$parallel <- list(n = p, autopar = NULL)
-      }
-
       oldfit$obj <- with(ee,
                        TMB::MakeADFun(data,
                                       parameters,
@@ -432,6 +424,15 @@ up2date <- function(oldfit, update_gauss_disp = FALSE) {
       oldfit$obj$env$last.par.best <- ee$last.par.best
       ##
   }
+
+  ## changed format of 'parallel' control to add autopar info
+  if (length(p <- oldfit$modelInfo$parallel) <= 1) {
+      if (!(is.null(p) || is.numeric(p))) {
+          stop("oldfit$modelInfo$parallel has an unexpected value")
+      }
+      oldfit$modelInfo$parallel <- list(n = p, autopar = NULL)
+  }
+
   ## dispersion was NULL rather than 1 in old R versions ...
   omf <- oldfit$modelInfo$family
   if (getRversion() >= "4.3.0" &&

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -305,9 +305,11 @@ NULL
 ##' Checks whether OpenMP has been successfully enabled for this
 ##' installation of the package. (Use the \code{parallel} argument
 ##' to \code{\link{glmmTMBControl}}, or set \code{options(glmmTMB.cores=[value])},
-##' to specify that computations should be done in parallel.)
+##' to specify that computations should be done in parallel.) To further
+##' trace OpenMP settings, use \code{options(glmmTMB_openmp_debug = TRUE)}.
 ##' @seealso \code{\link[TMB]{benchmark}}, \code{\link{glmmTMBControl}}
-##' @return \code{TRUE} or \code{FALSE} depending on availability of OpenMP
+##' @return \code{TRUE} or \code{FALSE} depending on availability of OpenMP,
+##' @aliases openmp
 ##' @export
 omp_check <- function() {
     .Call("omp_check", PACKAGE="glmmTMB")
@@ -410,6 +412,12 @@ up2date <- function(oldfit, update_gauss_disp = FALSE) {
                   oldfit$fit[[p]][nm == "betadisp"] <- oldfit$fit[[p]][nm == "betadisp"]/2
               }
           }
+      }
+
+      ## changed format of 'parallel' control to add autopar info
+      if (length(p <- oldfit$modelInfo$parallel) == 1 &&
+          is.numeric(p)) {
+          oldfit$modelInfo$parallel <- list(n = as.integer(p), autopar = NULL)
       }
 
       oldfit$obj <- with(ee,

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -415,9 +415,11 @@ up2date <- function(oldfit, update_gauss_disp = FALSE) {
       }
 
       ## changed format of 'parallel' control to add autopar info
-      if (length(p <- oldfit$modelInfo$parallel) == 1 &&
-          is.numeric(p)) {
-          oldfit$modelInfo$parallel <- list(n = as.integer(p), autopar = NULL)
+      if (length(p <- oldfit$modelInfo$parallel) == 1) {
+          if (!(is.null(p) || is.numeric(p))) {
+              stop("oldfit$modelInfo$parallel has an unexpected value")
+          }
+          oldfit$modelInfo$parallel <- list(n = p, autopar = NULL)
       }
 
       oldfit$obj <- with(ee,

--- a/glmmTMB/inst/misc/test_parallel.R
+++ b/glmmTMB/inst/misc/test_parallel.R
@@ -1,36 +1,44 @@
 ## remotes::install_local(".")
+cc <- commandArgs(trailingOnly = TRUE)
+do_test <- FALSE
+if (length(cc) > 0) do_test <- as.logical(cc[1])
 
+##' @param nt number of threads (NA -> use detectCores() to use all cores)
+##' @param N number of obs in sim data
+##' @param group number of groups in sim data (groups/N must be integer)
+##' @param seed random-number seed
 parallel_test <- function(nt=NA, N=1e5, groups=200, seed=1) {
     require(glmmTMB)
     nt_orig <- nt
     if (is.na(nt)) {
         nt <- parallel::detectCores()
     } else {
-        nt <- min(parallel::detectCores(),nt)
+        nt <- min(parallel::detectCores(), nt)
     }
     if (!is.null(seed)) set.seed(seed)
     xdata <- rnorm(N, 1, 2)
     data_use <- data.frame(obs = 1:N)
-    data_use <- within(data_use,
-    {
-        
+    data_use <- within(data_use, {
         group_var <- rep(seq(groups), times = nrow(data_use) / groups)
         group_intercept <- rnorm(groups, 0, 0.1)[group_var]
         xdata <- xdata
         ydata <- 0.3 + group_intercept + 0.5*xdata + rnorm(N, 0, 0.25)
     })
-    (t_serial <- system.time(
-         model3 <- glmmTMB(formula = ydata ~ 1 + xdata + (1 | group_var),
-                           data = data_use,
-                           control = glmmTMBControl(parallel = 1))
-     )
+    t_serial <- system.time(
+        model3 <- glmmTMB(formula = ydata ~ 1 + xdata + (1 | group_var),
+                          data = data_use,
+                          control = glmmTMBControl(parallel = 1))
     )
-    (t_parallel <- system.time(
-         update(model3,  control = glmmTMBControl(parallel = nt))
-     )
+    t_parallel_noauto <- system.time(
+        update(model3,  control = glmmTMBControl(parallel = list(n = nt, autopar = FALSE)))
     )
+    t_parallel_auto <- system.time(
+        update(model3,  control = glmmTMBControl(parallel = list(n = nt, autopar = TRUE)))
+    )
+
     ret <- list(t_serial=t_serial,
-                t_parallel=t_parallel,
+                t_parallel_noauto=t_parallel_noauto,
+                t_parallel_auto  =t_parallel_auto,
                 pars=list(nt=nt, N=N, groups=groups, seed=seed),
                 s_info=sessionInfo(),
                 p_info=help(package="glmmTMB"))
@@ -40,15 +48,16 @@ parallel_test <- function(nt=NA, N=1e5, groups=200, seed=1) {
 
 print.partest <- function(x, ...) {
     s <- x$t_serial[["elapsed"]]
-    p <- x$t_parallel[["elapsed"]]
+    pn <- x$t_parallel_noauto[["elapsed"]]
+    pa <- x$t_parallel_auto[["elapsed"]]
     cat(sprintf(
-       "elapsed time for N=%1.1g: serial=%1.1f, parallel=%1.1f (%d threads)\n",
-        x$pars$N,s,p,x$pars$nt))
-    cat(sprintf("ratio=%1.1f\n",s/p))
-    cat("platform: ",x$s_info$platform,"\n")
+        "elapsed time for N=%1.1g: serial=%1.1f, parallel_noauto=%1.1f, parallel_auto=%1.1f (%d threads)\n",
+        x$pars$N,s,pn,pa,x$pars$nt))
+    cat(sprintf("ratios=%1.1f (noauto), %1.1f (auto), %1.1f (noauto vs auto)\n",s/pn, s/pa, pn/pa))
+    cat("platform:", x$s_info$platform, "\n")
 }
 
-if (FALSE) {
-    ## test 
-    (p <- parallel_test(N=1e4))
-}
+## test
+options(glmmTMB_openmp_debug = TRUE)
+print(p <- parallel_test(nt = 4, N=1e4, groups = 250))
+

--- a/glmmTMB/man/glmmTMBControl.Rd
+++ b/glmmTMB/man/glmmTMBControl.Rd
@@ -10,7 +10,8 @@ glmmTMBControl(
   optimizer = nlminb,
   profile = FALSE,
   collect = FALSE,
-  parallel = getOption("glmmTMB.cores", 1L),
+  parallel = list(n = getOption("glmmTMB.cores", 1L), autopar =
+    getOption("glmmTMB.autopar", NULL)),
   eigval_check = TRUE,
   zerodisp_val = log(.Machine$double.eps)/4,
   start_method = list(method = NULL, jitter.sd = 0),
@@ -31,13 +32,18 @@ robustness when a model has many fixed effects}
 \item{collect}{(logical) Experimental option to improve speed by
 recognizing duplicated observations.}
 
-\item{parallel}{(integer) Set number of OpenMP threads to evaluate
-the negative log-likelihood in parallel. The default is to evaluate
-models serially (i.e. single-threaded); users can set a default value
-for an R session via \code{options(glmmTMB.cores=<value>)}. At present
-reduced-rank models (i.e., a covariance structure using \code{rr(...)})
-cannot be fitted in parallel; the number of threads will be automatically
-set to 1, with a warning if this overrides the user-specified value.}
+\item{parallel}{(named list with an integer value \code{n} and a logical value \code{autopar},
+e.g. \code{list(n=4L, autopar=TRUE)}) Set number of OpenMP threads to evaluate
+the negative log-likelihood in parallel, and determine whether to use auto-parallelization
+(see \code{\link[TMB]{openmp}}). The default is to evaluate
+models serially (i.e. single-threaded); users can set default values
+for an R session via \code{options(glmmTMB.cores=<value>, glmmTMB.autopar=<value>)}.
+An integer number of cores (only) can be passed instead of a list, in which case the default or
+previously set value of \code{autopar} will be used.
+At present reduced-rank models (i.e., a covariance structure using \code{rr(...)})
+cannot be fitted in parallel unless \code{autopar=TRUE}; the number of threads will be automatically
+set to 1, with a warning if this overrides the user-specified value.
+To trace OpenMP settings, use \code{options(glmmTMB_openmp_debug = TRUE)}.}
 
 \item{eigval_check}{Check eigenvalues of variance-covariance matrix? (This test may be very slow for models with large numbers of fixed-effect parameters.)}
 

--- a/glmmTMB/man/omp_check.Rd
+++ b/glmmTMB/man/omp_check.Rd
@@ -2,18 +2,20 @@
 % Please edit documentation in R/utils.R
 \name{omp_check}
 \alias{omp_check}
+\alias{openmp}
 \title{Check OpenMP status}
 \usage{
 omp_check()
 }
 \value{
-\code{TRUE} or \code{FALSE} depending on availability of OpenMP
+\code{TRUE} or \code{FALSE} depending on availability of OpenMP,
 }
 \description{
 Checks whether OpenMP has been successfully enabled for this
 installation of the package. (Use the \code{parallel} argument
 to \code{\link{glmmTMBControl}}, or set \code{options(glmmTMB.cores=[value])},
-to specify that computations should be done in parallel.)
+to specify that computations should be done in parallel.) To further
+trace OpenMP settings, use \code{options(glmmTMB_openmp_debug = TRUE)}.
 }
 \seealso{
 \code{\link[TMB]{benchmark}}, \code{\link{glmmTMBControl}}

--- a/glmmTMB/tests/testthat/test-basics.R
+++ b/glmmTMB/tests/testthat/test-basics.R
@@ -6,7 +6,7 @@ stopifnot(require("testthat"),
 drop_version <- function(obj) {
     obj$modelInfo$packageVersion <- NULL
     obj$modelInfo$family$initialize <- NULL  ## updated initialization expressions
-    obj
+    obj$modelInfo$parallel <- NULL   ## parallel component changed from int to list
 }
 
 expect_equal_nover <- function(x,y,...) {

--- a/glmmTMB/tests/testthat/test-control.R
+++ b/glmmTMB/tests/testthat/test-control.R
@@ -78,3 +78,9 @@ test_that("parallel regions", {
 
 
 })
+
+test_that("autopar-only parallel", {
+    m1 <- glmmTMB(count ~ mined + (1|site), family = poisson, data = Salamanders)
+    m2 <- update(m1, control = glmmTMBControl(parallel = list(autopar = TRUE)))
+    expect_equal(fixef(m1), fixef(m2))
+})


### PR DESCRIPTION
This allows users to take advantage of the new autopar stuff in TMB (in particular, to allow parallelization with rr models).

* might need to update TMB dependence to a newer version (although this *might* still work even with older TMB versions -- haven't tested)
* this *should* be harmless to include in a new release, but I might wait until after the next CRAN-mandated release just to give ourselves a bit more time
* at the moment `autopar = FALSE` is the default, which I think makes sense until we have more info. For example, this test shows that for a simple example non-autopar is slightly faster than autopar (with an even bigger advantage for larger N ...)
* may need to worry about the (unlikely) event that glmmTMB has been compiled/installed using CppAD rather than (default) TMBAd?
* should update the parallel vignette accordingly (this could also close out https://github.com/glmmTMB/glmmTMB/issues/713)

Separately, can confirm that this works to speed up `rr()` fits (which are only possible with autopar).

```
$ Rscript --vanilla inst/misc/test_parallel.R TRUE
Loading required package: glmmTMB
setting OpenMP threads to 1L, autopar = NULL
setting OpenMP threads to 1L, autopar = FALSE
setting OpenMP threads to 4L, autopar = FALSE
setting OpenMP threads to 1L, autopar = FALSE
setting OpenMP threads to 4L, autopar = TRUE
setting OpenMP threads to 1L, autopar = FALSE
elapsed time for N=1e+04: serial=3.6, parallel_noauto=1.3, parallel_auto=1.8 (4 threads)
ratios=2.8 (noauto), 2.0 (auto), 0.7 (noauto vs auto)
platform: x86_64-pc-linux-gnu 
```