### PR TITLE
pass known covstructs to reformulas fns

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -707,7 +707,7 @@ getXReTrms <- function(formula, mf, fr, ranOK=TRUE, type="",
         }
 
         ## formula <- Reaction ~ s(Days) + (1|Subject)
-        ss <- splitForm(formula)
+        ss <- splitForm(formula, specials = c(names(.valid_covstruct), "s"))
 
         ## contains: c("Zt", "theta", "Lind", "Gp", "lower", "Lambdat", "flist", "cnms", "Ztlist", "nl")
         ## we only need "Zt", "flist", "Gp", "cnms", "Ztlist" (I think)
@@ -1242,7 +1242,7 @@ glmmTMB <- function(
     for (i in seq_along(formList)) {
         f <- formList[[i]] ## abbreviate
         ## substitute "|" by "+"; drop specials
-        f <- noSpecials(sub_specials(f),delete=FALSE)
+        f <- noSpecials(sub_specials(f), delete=FALSE, , specials = c(names(.valid_covstruct), "s"))
         formList[[i]] <- f
     }
     combForm <- do.call(addForm,formList)


### PR DESCRIPTION
with the export of formula processing to `reformulas`, we need to work a little harder to make sure that the list of known 'specials' (covariance structures etc.) is passed to the formula-processing functions. As far as I can tell this handles all the required cases. 

This should resolve https://github.com/glmmTMB/glmmTMB/issues/1069, https://github.com/bbolker/reformulas/issues/2

It's a little bit annoying to test because it involves adding new covariance structures to the code and seeing if they are recognized properly.
