### PR TITLE
Save smooth info

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -327,7 +327,7 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
     }
 
     ## fixme: may need to modify here, or modify getXReTrms, for smooth-term prediction
-    condList  <- getXReTrms(formula, mf, fr, type="conditional", contrasts=contrasts, sparse=sparseX[["cond"]],
+    condList  <- getXReTrms(formula, mf, fr, type="coNditional", contrasts=contrasts, sparse=sparseX[["cond"]],
                             old_smooths = old_smooths$cond)
     ziList    <- getXReTrms(ziformula, mf, fr, type="zero-inflation", contrasts=contrasts, sparse=sparseX[["zi"]],
                             old_smooths = old_smooths$zi)
@@ -653,7 +653,6 @@ getXReTrms <- function(formula, mf, fr, ranOK=TRUE, type="",
         }
         if (has_smooths) {
             if (sparse) warning("smooth terms may not be compatible with sparse X matrices")
-<<<<<<< HEAD
             for (si in seq_along(smooth_terms2)) {
                 cnm <- colnames(X)  ## need to update cnm after each added term ...
                 s <- smooth_terms2[[si]]
@@ -760,17 +759,17 @@ getXReTrms <- function(formula, mf, fr, ranOK=TRUE, type="",
             ##  ... which bits are actually used hereafter?
             avec[nonbarpos] <-  length(augReTrms$flist)
             attr(augReTrms$flist, "assign") <- avec
-            browser()
-            ncol_fun <- function(x) if (is.null(x)) 0 else ncol(x))
+            ncol_fun <- function(x) if (is.null(x)) 0 else ncol(x)
             b_lens <- vapply(augReTrms$Ztlist, ncol_fun, FUN.VALUE = numeric(1))
             for (i in seq_along(smooth_terms2)) {
                 s <- smooth_terms2[[i]]
                 pos <- nonbarpos[i]
                 Zt <- as(t(s$re$rand$Xr), "dgCMatrix")
                 b_lens[pos] <- ncol(Zt)
-                b_inds <- sum(b_lens[seq_along(b_lens)<i]) + seq(ncol(Zt))
-                ## FIXME: where does this get stored?
-                re$b_inds <- b_inds
+                b_ind <- sum(b_lens[seq_along(b_lens)<i]) + seq(ncol(Zt))
+                browser()
+                ## perhaps redundant with b indices stored elsewhere
+                smooth_terms2[[i]]$re$b_ind <- b_ind
                 npar <- nrow(Zt)
                 augReTrms$Ztlist[[pos]] <- Zt
                 nm <- attr(s$re$rand$Xr, "s.label")
@@ -779,6 +778,7 @@ getXReTrms <- function(formula, mf, fr, ranOK=TRUE, type="",
                 augReTrms$cnms[[pos]] <- paste0("dummy", seq(npar))
                 names(augReTrms$cnms)[pos] <- "dummy"
             }
+            browser()
             ## store smooth info in relevant spots
             for (i in seq_along(nonbarpos)) {
                 augReTrms$smooth_info[[nonbarpos[i]]] <- smooth_terms2[[i]]

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -767,7 +767,6 @@ getXReTrms <- function(formula, mf, fr, ranOK=TRUE, type="",
                 Zt <- as(t(s$re$rand$Xr), "dgCMatrix")
                 b_lens[pos] <- ncol(Zt)
                 b_ind <- sum(b_lens[seq_along(b_lens)<i]) + seq(ncol(Zt))
-                browser()
                 ## perhaps redundant with b indices stored elsewhere
                 smooth_terms2[[i]]$re$b_ind <- b_ind
                 npar <- nrow(Zt)
@@ -778,7 +777,6 @@ getXReTrms <- function(formula, mf, fr, ranOK=TRUE, type="",
                 augReTrms$cnms[[pos]] <- paste0("dummy", seq(npar))
                 names(augReTrms$cnms)[pos] <- "dummy"
             }
-            browser()
             ## store smooth info in relevant spots
             for (i in seq_along(nonbarpos)) {
                 augReTrms$smooth_info[[nonbarpos[i]]] <- smooth_terms2[[i]]

--- a/misc/smooth_issues.R
+++ b/misc/smooth_issues.R
@@ -1,0 +1,50 @@
+## extend examples?
+## deal with b-mapping stuff
+## conditional REs?
+## expose X-construction helper function?
+
+## comparing
+
+library(glmmTMB)
+library(mgcv)
+library(scam)
+
+data("Nile")
+ndat <- data.frame(time = c(time(Nile)), val = c(Nile))
+
+sm1 <- glmmTMB(val ~ s(time, bs = "tp"), data = ndat,
+                REML = TRUE, start = list(theta = 5))
+sm1_gcv <- mgcv::gam(val ~ s(time, bs = "tp"), data = ndat,
+               method = "REML")
+plot(val ~ time, data = ndat)
+lines(ndat$time, predict(sm1))
+lines(ndat$time, predict(sm1_gcv), col = 2)
+if (requireNamespace("scam")) {
+  sm1M <- glmmTMB(val ~ s(time, bs = "mpd"), data = ndat,
+               REML = TRUE, start = list(theta = 5))
+  sm1M_scam <- scam(val ~ s(time, bs = "mpd"), data = ndat)
+  
+  lines(ndat$time, predict(sm1M), lty = 2, col = 4)
+  lines(ndat$time, predict(sm1M_scam), lty = 2, col = 4)
+}
+
+
+## save smooth info -- where?
+devtools::load_all("glmmTMB")
+data("Nile")
+ndat <- data.frame(time = c(time(Nile)), val = c(Nile))
+
+debug(mkTMBStruc)
+debug(getXReTrms)
+
+sm1 <- glmmTMB(val ~ s(time, bs = "tp"), data = ndat,
+                REML = TRUE, start = list(theta = 5))
+
+
+lapply(sm1$modelInfo$reTrms,
+       \(y) lapply(y$smooth_info, \(x) x$re$beta_ind))
+
+lapply(sm1$modelInfo$reTrms,
+       \(y) lapply(y$smooth_info, \(x) x$re$b_ind))
+
+

--- a/misc/smooth_issues.R
+++ b/misc/smooth_issues.R
@@ -34,12 +34,8 @@ devtools::load_all("glmmTMB")
 data("Nile")
 ndat <- data.frame(time = c(time(Nile)), val = c(Nile))
 
-debug(mkTMBStruc)
-debug(getXReTrms)
-
 sm1 <- glmmTMB(val ~ s(time, bs = "tp"), data = ndat,
                 REML = TRUE, start = list(theta = 5))
-
 
 lapply(sm1$modelInfo$reTrms,
        \(y) lapply(y$smooth_info, \(x) x$re$beta_ind))


### PR DESCRIPTION
This is preliminary/to soon to actually merge, but it is now possible to extract information on which indices of `beta` and `b` correspond to each smooth term in a model:
```r
devtools::load_all("glmmTMB")
data("Nile")
ndat <- data.frame(time = c(time(Nile)), val = c(Nile))

sm1 <- glmmTMB(val ~ s(time, bs = "tp"), data = ndat,
                REML = TRUE, start = list(theta = 5))

lapply(sm1$modelInfo$reTrms,
       \(y) lapply(y$smooth_info, \(x) x$re$beta_ind))

lapply(sm1$modelInfo$reTrms,
       \(y) lapply(y$smooth_info, \(x) x$re$b_ind))
```

This should probably be built into a `getME()` option ... (and possibly we should simultaneously set up the ability to extract `b_ind` for *any* RE term, or any component of a RE term, which will help with the `extend_re_form` branch ...)
