### PR TITLE
make sure to REPORT corrdisp, sddisp (GH #1058)

### DIFF
--- a/glmmTMB/src/glmmTMB.cpp
+++ b/glmmTMB/src/glmmTMB.cpp
@@ -1024,6 +1024,8 @@ Type objective_function<Type>::operator() ()
   REPORT(sd);
   REPORT(corrzi);
   REPORT(sdzi);
+  REPORT(corrdisp);
+  REPORT(sddisp);
   REPORT(fact_load);
   SIMULATE {
     REPORT(yobs);

--- a/glmmTMB/tests/testthat/test-VarCorr.R
+++ b/glmmTMB/tests/testthat/test-VarCorr.R
@@ -215,3 +215,18 @@ test_that("blockCode set correctly in VarCorr", {
                      )
     expect_equal(attr(VarCorr(model)[["zi"]]$group, "blockCode"), c(ar1=3))
 })
+
+test_that("VarCorr for models with RE in dispersion", {
+    data("sleepstudy", package = "lme4")
+
+    fit <- suppressWarnings(glmmTMB(Reaction ~ Days + (Days | Subject),
+                   dispformula = ~ Days + (Days | Subject),
+                   data = sleepstudy))
+
+    vc <- VarCorr(fit)
+    expect_equal(c(vc$disp$Subject),
+                   c(0.127005710245793, -4.71258573290661e-17, -4.71258573290661e-17, 
+                     1.865081358102e-32),
+                 tolerance = 1e-5)
+})
+


### PR DESCRIPTION
This one is pretty straightforward; we forgot to update the C++ to `REPORT()` some quantities, broke `VarCorr()`
