### PR TITLE
profiling models with mapped parameters

### DIFF
--- a/glmmTMB/R/profile.R
+++ b/glmmTMB/R/profile.R
@@ -78,7 +78,7 @@ profile.glmmTMB <- function(fitted,
     parm <- getParms(parm, fitted, full=TRUE)
 
     ## only need selected SDs
-    sds <- sqrt(diag(vcov(fitted,full=TRUE)))
+    sds <- sqrt(diag(vcov(fitted, full=TRUE, include_nonest = FALSE)))
     sds <- sds[parm]
 
     if (!is.null(stderr)) {

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -9,6 +9,7 @@
     \itemize{
       \item fix newly introduced bug in Pearson residuals for
       zero-inflated models (GH #1101)
+      \item likelihood profiling now works for models with mapped parameters
     } % itemize
   } % bug fixes
 } % 1.1.10.9000
@@ -72,7 +73,7 @@
       \code{reformulas} package rather than from \code{lme4}
     } % itemize
   } % other changes
-} % 1.1.9-9000
+} % 1.1.10
   
 \section{CHANGES IN VERSION 1.1.9 (2024-03-20)}{
   \subsection{USER-VISIBLE CHANGES}{

--- a/glmmTMB/tests/testthat/test-methods.R
+++ b/glmmTMB/tests/testthat/test-methods.R
@@ -730,6 +730,18 @@ test_that("dunn-smyth residuals", {
                  tolerance = 1e-6)
 })
 
+test_that("profiling with mapped parameters", {
+    data("sleepstudy", package = "lme4")
+    m1 <- glmmTMB(Reaction ~ Days,
+                  data = sleepstudy,
+                  family = gaussian,
+                  map = list(beta = factor(c(NA, 1))),
+                  start = list(beta = c(250, 0)))
+
+    pp <- profile(m1)                         
+    expect_equal(dim(pp), c(50, 3))
+})
+
 # This test started also giving a warning on os "mac".
 # test_that("bad inversion in vcov", {
 #     skip_on_os(c("windows", "linux"))


### PR DESCRIPTION
This was a very small change (add `include_nonest = FALSE` to a `vcov()` call)