### PR TITLE
more careful evaluation of  family component (fix #1133)

### DIFF
--- a/glmmTMB/R/family.R
+++ b/glmmTMB/R/family.R
@@ -32,8 +32,10 @@ make_family <- function(x, link, needs_nonneg = FALSE, needs_int = FALSE) {
         x <- c(x,list(aic=function(...) NA_real_))
     }
     if (is.null(x$initialize)) {
-        x <- c(x,list(initialize=
-                          substitute(env = list(FAMILY=x$family),
+        x <- c(x, list(initialize=
+                           substitute(env = list(FAMILY=x$family,
+                                                 needs_nonneg = needs_nonneg,
+                                                 needs_int = needs_int),
             expr = expression({
             ## should handle log-links adequately
             mustart <- y+0.1
@@ -50,6 +52,10 @@ make_family <- function(x, link, needs_nonneg = FALSE, needs_int = FALSE) {
                 }
             }
             }))))
+        ## strip one layer of protection
+        ##   str == 'language expression ...' -> 'expression ...'
+        x$initialize <- eval(x$initialize)
+
     }
         
     if (is.null(x$dev.resids)) {

--- a/glmmTMB/tests/testthat/test-families.R
+++ b/glmmTMB/tests/testthat/test-families.R
@@ -542,3 +542,17 @@ test_that("skewnormal family", {
                  c(`Skewnormal shape` = -6.12362878509844),
                  tolerance = 1e-6)
 })
+
+test_that("make_family initialize works", {
+    ## GH #1133
+    if (require(effects)) {
+        data("sleepstudy", package = "lme4")
+        m2 <- glmmTMB(round(Reaction) ~ Days + (1 | Subject), sleepstudy,
+                      family = truncated_nbinom2)
+        ee <- suppressWarnings(effects::Effect("Days", m3))
+        expect_equal(c(ee$fit),
+                     c(5.5317435373068, 5.6003872162399,
+                       5.669030895173, 5.77199641357265, 
+                       5.84064009250575))
+    }
+})

--- a/glmmTMB/tests/testthat/test-families.R
+++ b/glmmTMB/tests/testthat/test-families.R
@@ -549,7 +549,7 @@ test_that("make_family initialize works", {
         data("sleepstudy", package = "lme4")
         m2 <- glmmTMB(round(Reaction) ~ Days + (1 | Subject), sleepstudy,
                       family = truncated_nbinom2)
-        ee <- suppressWarnings(effects::Effect("Days", m3))
+        ee <- suppressWarnings(effects::Effect("Days", m2))
         expect_equal(c(ee$fit),
                      c(5.5317435373068, 5.6003872162399,
                        5.669030895173, 5.77199641357265, 


### PR DESCRIPTION
I think this should be OK, but I am mildly nervous about squeezing it into the upcoming release because it does change user-visible behaviour ... on the other hand it would be a shame to leave it out ... (not sure why the issues only become apparent when calling `effect::Effect()`, but that's part of the mystery of delayed evaluation ...)

Maybe we can merge this and then run reverse-dependency checks again ... ??