### PR TITLE
add homcs cov structure; covstruct vignette tweaks

### DIFF
--- a/glmmTMB/R/enum.R
+++ b/glmmTMB/R/enum.R
@@ -46,7 +46,8 @@
   rr = 9,
   homdiag = 10,
   propto = 11,
-  hetar1 = 12
+  hetar1 = 12,
+  homcs = 13
 )
 .valid_zipredictcode <- c(
   corrected = 0,

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -996,7 +996,9 @@ getReStruc <- function(reTrms, ss=NULL, aa=NULL, reXterms=NULL, fr=NULL) {
                "toep" = 2 * blksize - 1,
                "rr" = blksize * blkrank - (blkrank - 1) * blkrank / 2, #rr
                "homdiag" = 1,  ## (homogeneous) diag
-               "propto" = blksize * (blksize+1) / 2 + 1 #propto (same as us, plus one extra for proportional param)
+               "propto" = blksize * (blksize+1) / 2 + 1, #propto (same as us, plus one extra for proportional param)
+               "homcs" = 2,
+               stop(sprintf("undefined number of parameters for covstruct '%s'", struc))
                )
     }
     blockNumTheta <- mapply(parFun, ss, blksize, blkrank, SIMPLIFY=FALSE)

--- a/glmmTMB/src/glmmTMB.cpp
+++ b/glmmTMB/src/glmmTMB.cpp
@@ -80,7 +80,8 @@ enum valid_covStruct {
   propto_covstruct = 11,
   // should perhaps be next to homdiag but don't want to mess
   //  up interpretation of stored fits ...
-  hetar1_covstruct = 12
+  hetar1_covstruct = 12,
+  homcs_covstruct = 13
 };
 
 // should probably be named just 'predictCode';
@@ -386,11 +387,19 @@ Type termwise_nll(array<Type> &U, vector<Type> theta, per_term_info<Type>& term,
     term.corr = nldens.cov(); // For report
     term.sd = sd;             // For report
   }
-  else if (term.blockCode == cs_covstruct){
+  else if (term.blockCode == cs_covstruct || term.blockCode == homcs_covstruct) {
     // case: cs_covstruct
     int n = term.blockSize;
-    vector<Type> logsd = theta.head(n);
-    Type corr_transf = theta(n);
+    int nsd = (term.blockCode == cs_covstruct ? n : 1);
+    vector<Type> logsd(n);
+    for (int i = 0; i < n; i++) {
+      if (term.blockCode == cs_covstruct) {
+	logsd(i) = theta(i);
+      } else {
+	logsd(i) = theta(0);
+      }
+    }
+    Type corr_transf = theta(nsd);
     vector<Type> sd = exp(logsd);
     Type a = Type(1) / (Type(n) - Type(1));
     Type rho = invlogit(corr_transf) * (Type(1) + a) - a;

--- a/glmmTMB/tests/testthat/test-varstruc.R
+++ b/glmmTMB/tests/testthat/test-varstruc.R
@@ -23,6 +23,12 @@ test_that("cs_us", {
 })
 
 test_that("cs_homog", {
+    fm_csh   <- glmmTMB(Reaction ~ Days + homcs(Days | Subject), sleepstudy)
+    vv <- unname(diag(VarCorr(fm_csh)[["cond"]][["Subject"]]))
+    expect_identical(vv[1], vv[2])
+})
+
+test_that("cs_homog", {
 ## *homogenous* compound symmetry vs. nested random effects
     expect_equal(logLik(fm_nest),logLik(fm_nest_lmer))
 

--- a/glmmTMB/vignettes/covstruct.rmd
+++ b/glmmTMB/vignettes/covstruct.rmd
@@ -52,8 +52,10 @@ set.seed(1)
 ## Sys.setenv(NOT_CRAN="true")
 ```
 
+## Overview
+
 This vignette demonstrates some of the covariance structures available in the `glmmTMB` package.
-Currently the available covariance structures are:
+The currently available covariance structures are:
 
 <!-- not sure why |x| for abs value isn't working in MathJax/LateX within kable table ... -->
 
@@ -64,8 +66,9 @@ ctab <- read.delim(sep = "#", comment = "",
            text = "
  Covariance                       # Notation      # no. parameters # Requirement  # Parameters
  Unstructured (general positive definite)      # `us`          #  $n(n+1)/2$     # # See [Mappings]
- Heterogeneous Toeplitz           # `toep`        #  $2n-1$         #     # log-SDs ($\\theta_1-\\theta_n$); correlations $\\rho_k = \\theta_{n+k}/\\sqrt{1+\\theta_{n+k}^2}$, $k = \\textrm{abs}(i-j+1)$
+ Heterogeneous Toeplitz           # `toep`        #  $2n-1$         #     # log-standard deviations ($\\theta_1-\\theta_n$); correlations $\\rho_k = \\theta_{n+k}/\\sqrt{1+\\theta_{n+k}^2}$, $k = \\textrm{abs}(i-j+1)$
  Het. compound symmetry  # `cs`          #  $n+1$    #      # log-SDs ($\\theta_1-\\theta_n$); correlation $\\{a=1/(n-1); \\rho = \\textrm{plogis}(\\theta_{n+1}) \\cdot (1+a) -a \\}$
+ Homogeneous compound symmetry  # `homcs`          #  $2$    #      # log-SD ($\\theta_1$); correlation $\\{a=1/(n-1); \\rho = \\textrm{plogis}(\\theta_{2}) \\cdot (1+a) -a \\}$
  Homogenous diagonal     # `homdiag`     #  $1$      #  # log-SD
  Het. diagonal           # `diag`        #  $n$            #  # log-SDs
  AR(1)                            # `ar1`         #  $2$            # Unit spaced levels # log-SD; $\\rho = \\left(\\theta_2/\\sqrt{1+\\theta_2^2}\\right)^{d_{ij}}$
@@ -73,8 +76,8 @@ ctab <- read.delim(sep = "#", comment = "",
  Spatial exponential              # `exp`         #  $2$            # Coordinates # log-SD; log-scale ($\\rho = \\exp(-\\exp(-\\theta_2) d_{ij})$)
  Spatial Gaussian                 # `gau`         #  $2$            # Coordinates # log-SD; log-scale ($\\rho = \\exp(-\\exp(-2\\theta_2) d_{ij}^2$)
  Spatial Matèrn                   # `mat`         #  $3$            # Coordinates # log-SD, log-range, log-shape (power)
- Reduced-rank                     # `rr`          #  $nd-d(d-1)/2$  # rank (d)    
- Proportional                       # `propto`      #  $1$            # Variance-covariance matrix
+ Reduced-rank                     # `rr`          #  $nd-d(d-1)/2$  # rank (d)    # Factor loading matrix (see [Reduced-rank])
+ Proportional                       # `propto`      #  $1$            # Variance-covariance matrix # log(proportionality constant)
 "
 )
 knitr::kable(ctab)


### PR DESCRIPTION
The homogeneous compound-symmetric structure can also be achieved by using `map`, but having it available as a built-in structure is easier for users [they don't have to know as much about the underlying structure of the `theta` parameter vector/understand how `map=` works].