### PR TITLE
Rankdefprior2

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -1685,6 +1685,10 @@ glmmTMBControl <- function(optCtrl=NULL,
           kept_indices <- match(colnames(adjX), colnames(curX))
           TMBStruc$parameters[[beta_name]] <- TMBStruc$parameters[[beta_name]][kept_indices]
           TMBStruc$data.tmb[[whichX]] <- adjX
+
+          ## if priors on parameters specified, adjust accordingly
+          browser()
+            
         } ## if matrix was adjusted
       } ## loop over X components
     } ## if rank_check == 'adjust'

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -355,15 +355,20 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
   ## don't want to destroy user-specified prior info by writing
   ##  over; we want the user-spec version in modelInfo
 
+  Xlist <- list(X = denseXval("cond",condList),
+                  XS = sparseXval("cond",condList),
+                  Xzi = denseXval("zi",ziList),
+                  XziS = sparseXval("zi",ziList),
+                  Xdisp = denseXval("disp",dispList),
+                  XdispS = sparseXval("disp",dispList))
+
+  if(control$rank_check %in% c('warning','stop','adjust')) {
+      Xlist <- .checkRankX(Xlist, control$rank_check)
+  }
+
   ## FIXME: would be nice to be able to get this with less info
   ## (for external testing etc.) but ... ??
 
-    
-  ## isolate names for localizing priors
-  get_fixnm <- function(x) c(colnames(x$X), colnames(x$XS))
-  fix_nms <- list(cond = get_fixnm(condList),
-                  zi = get_fixnm(ziList),
-                  disp = get_fixnm(dispList))
   comb_re <- function(component) {
       restruc <- get(paste0(component, "ReStruc"))
       rList <- get(paste0(component, "List"))
@@ -371,22 +376,21 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
       names(res) <- names(restruc)
       res
   }
-
   re_info <- list(cond = comb_re("cond"), zi = comb_re("zi"))
+
+  ## isolate names for localizing priors
+  get_fixnm <- function(x) c(colnames(x$X), colnames(x$XS))
+  fix_nms <- list(cond = get_fixnm(Xlist[c("X", "Xs")]),
+                  zi = get_fixnm(Xlist[c("Xzi", "XziS")]),
+                  disp = get_fixnm(Xlist[c("Xdisp", "XdispS")]))
 
   ## easy way to get lengths of theta of individual components??
   prior_struc <- proc_priors(priors, info = list(fix = fix_nms, re = re_info))
 
   data.tmb <- namedList(
-    ## fixed-effect (X) and random-effect (Z), dense and sparse model matrices    
-    X = denseXval("cond",condList),
-    XS = sparseXval("cond",condList),
+    ## random-effect (Z), dense and sparse model matrices    
     Z = condList$Z,
-    Xzi = denseXval("zi",ziList),
-    XziS = sparseXval("zi",ziList),
     Zzi = ziList$Z,
-    Xdisp = denseXval("disp",dispList),
-    XdispS = sparseXval("disp",dispList),
     Zdisp=dispList$Z,
     
     ## use c() on yobs, size to strip attributes such as 'AsIs'
@@ -411,8 +415,8 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
     whichPredict = whichPredict
   )
 
-    ## add prior info
-    data.tmb <- c(data.tmb, prior_struc)
+    ## add X matrices, prior info
+    data.tmb <- c(data.tmb, Xlist, prior_struc)
 
   # function to set value for dorr
   rrVal <- function(lst) if(any(lst$ss == "rr") || any(lst$ss == "propto")) 1 else 0
@@ -1638,7 +1642,7 @@ glmmTMBControl <- function(optCtrl=NULL,
 ##' When rank_check='adjust', drop columns in X and remove associated parameters.
 ##' @importFrom Matrix rankMatrix
 ##' @keywords internal
-.checkRankX <- function(TMBStruc, rank_check=c('warning','adjust','stop','skip')) {
+.checkRankX <- function(Xlist, rank_check=c('warning','adjust','stop','skip')) {
   rank_check <- match.arg(rank_check)
   Xnames <- c(conditional = "X", conditional = "XS", "zero-inflation" = "Xzi", "zero-inflation" = "XziS", dispersion = "Xdisp", dispersion = "XdispS")
   betanames <- gsub("X", "beta",
@@ -1648,9 +1652,9 @@ glmmTMBControl <- function(optCtrl=NULL,
   if(rank_check %in% c('stop', 'warning')){
     for (whichX in Xnames) {
       # only attempt rankMatrix if the X matrix contains info
-      if(prod(dim(TMBStruc$data.tmb[[whichX]])) == 0) next
+      if(prod(dim(Xlist[[whichX]])) == 0) next
         ## if X is rank deficient, stop or throw a warning
-        if (Matrix::rankMatrix(TMBStruc$data.tmb[[whichX]]) < ncol(TMBStruc$data.tmb[[whichX]])){
+        if (Matrix::rankMatrix(Xlist[[whichX]]) < ncol(Xlist[[whichX]])){
           # determine the model type for a more indicative error or warning message
           model_type <- names(Xnames)[match(whichX, Xnames)]
           action <- get(rank_check, "package:base")
@@ -1660,9 +1664,9 @@ glmmTMBControl <- function(optCtrl=NULL,
   } else
     if(rank_check == 'adjust'){
       for(whichX in Xnames){
-        # only attempt adjutment if the X matrix contains info
-        if(prod(dim(TMBStruc$data.tmb[[whichX]])) == 0) next
-        curX <- TMBStruc$data.tmb[[whichX]]
+        # only attempt adjustment if the X matrix contains info
+        if(prod(dim(Xlist[[whichX]])) == 0) next
+        curX <- Xlist[[whichX]]
         # use .adjustX to only keep linearly dependent columns of X matrix
         adjX <- .adjustX(curX)
         # if columns were dropped, update variables accordingly
@@ -1680,19 +1684,12 @@ glmmTMBControl <- function(optCtrl=NULL,
           # retain names of dropped column for use in model output
           attr(adjX, "col.dropped") <- setNames(dropped_indices, dropped_names)
 
-          ## reduce parameters of appropriate component
-          beta_name <- betanames[match(whichX, Xnames)]
-          kept_indices <- match(colnames(adjX), colnames(curX))
-          TMBStruc$parameters[[beta_name]] <- TMBStruc$parameters[[beta_name]][kept_indices]
-          TMBStruc$data.tmb[[whichX]] <- adjX
+          Xlist[[whichX]] <- adjX
 
-          ## if priors on parameters specified, adjust accordingly
-          browser()
-            
         } ## if matrix was adjusted
       } ## loop over X components
     } ## if rank_check == 'adjust'
-  return(TMBStruc)
+  return(Xlist)
 }
 
 ##' Checks if the row or column names of the matrix in aa matches cnms
@@ -1812,10 +1809,6 @@ fitTMB <- function(TMBStruc, doOptim = TRUE) {
         ## original data (with duplicates) after fitting.
         data.tmb.old <- TMBStruc$data.tmb
         TMBStruc$data.tmb <- .collectDuplicates(TMBStruc$data.tmb)
-    }
-
-    if(control$rank_check %in% c('warning','stop','adjust')){
-      TMBStruc <- .checkRankX(TMBStruc, control$rank_check)
     }
 
     ## avoid repetition; rely on environment for parameters

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -362,7 +362,7 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
                   Xdisp = denseXval("disp",dispList),
                   XdispS = sparseXval("disp",dispList))
 
-  if(control$rank_check %in% c('warning','stop','adjust')) {
+  if (control$rank_check %in% c('warning','stop','adjust')) {
       Xlist <- .checkRankX(Xlist, control$rank_check)
   }
 
@@ -379,7 +379,8 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
   re_info <- list(cond = comb_re("cond"), zi = comb_re("zi"))
 
   ## isolate names for localizing priors
-  get_fixnm <- function(x) c(colnames(x$X), colnames(x$XS))
+  get_fixnm <- function(x) c(colnames(x[[1]]), colnames(x[[2]]))
+    
   fix_nms <- list(cond = get_fixnm(Xlist[c("X", "Xs")]),
                   zi = get_fixnm(Xlist[c("Xzi", "XziS")]),
                   disp = get_fixnm(Xlist[c("Xdisp", "XdispS")]))
@@ -1601,7 +1602,7 @@ glmmTMBControl <- function(optCtrl=NULL,
 ##' @keywords internal
 .adjustX <- function(X, tol=NULL, why_dropped=FALSE){
   # perform QR decomposition
-  qr_X <- Matrix::qr(X)
+  qr_X <- Matrix::qr(X[Matrix::rowSums(is.na(X)) == 0, , drop = FALSE])
   # check if adjustment is necessary
   if(Matrix::qr2rankMatrix(qr_X) < ncol(X)){
     # base qr

--- a/glmmTMB/R/predict.R
+++ b/glmmTMB/R/predict.R
@@ -425,7 +425,6 @@ predict.glmmTMB <- function(object,
       ## use re.form, ll. 749ff of utils.R to decide which
       ##  b values to set to zero.  OK to map _all_ values in this case
       ##  (unless they're in newparams) ?
-      ## browser()           
       TMBStruc <- within(TMBStruc, {
           parameters$b[] <- 0
           mapArg$b <- factor(rep(NA,length(parameters$b)))

--- a/glmmTMB/man/dot-checkRankX.Rd
+++ b/glmmTMB/man/dot-checkRankX.Rd
@@ -5,7 +5,7 @@
 \title{Check for identifiability of fixed effects matrices X, Xzi, Xdisp.
 When rank_check='adjust', drop columns in X and remove associated parameters.}
 \usage{
-.checkRankX(TMBStruc, rank_check = c("warning", "adjust", "stop", "skip"))
+.checkRankX(Xlist, rank_check = c("warning", "adjust", "stop", "skip"))
 }
 \description{
 Check for identifiability of fixed effects matrices X, Xzi, Xdisp.

--- a/glmmTMB/tests/testthat/test-predict.R
+++ b/glmmTMB/tests/testthat/test-predict.R
@@ -55,8 +55,6 @@ test_that("new levels in AR1 (OK)", {
                    "Predicting new random effect levels")
 })
 
-context("Predict two-column response case")
-
 test_that("two-column response", {
     skip_on_cran()
     fm <- glmmTMB( cbind(count,4) ~ mined, family=betabinomial,

--- a/glmmTMB/tests/testthat/test-priors.R
+++ b/glmmTMB/tests/testthat/test-priors.R
@@ -152,3 +152,19 @@ test_that("prior specs", {
 
     expect_equal(getME(g8p, "theta"), getME(g9p, "theta"))
 })
+
+## from GH#1146
+
+rankdeficientdata <- data.frame(
+  group = rep(c('g1', 'g2', 'g3'), c(10, 20, 10)),
+  year = rep(c('y1', 'y2'), each = 20)
+)
+rankdeficientdata$y <- simulate_new(~group*year,
+                  seed = 101,
+                  newdata = rankdeficientdata,
+                  newparams = list(beta=c(10,2,4,1), betadisp = log(3)))[[1]]
+
+test_that("dropping priors for rank-def X matrix", {
+    glmmTMB(y ~ group * year, data = rankdeficientdata,
+            priors = data.frame(prior = c('normal(0, 10)'), class = c('fixef')))
+})

--- a/glmmTMB/tests/testthat/test-priors.R
+++ b/glmmTMB/tests/testthat/test-priors.R
@@ -142,7 +142,6 @@ test_that("prior specs", {
     )
     expect_error(update(m2, prior = prior7), "can't match")
 
-
     prior8 <- prior7
     prior8$coef[4] <- "site"
     suppressWarnings(g8p <- update(m2, prior = prior8))


### PR DESCRIPTION
Fixes #1146, I think.

This could conceivably add a tiny bit of overhead because we now have to check for `NA` values in FE model matrices (it might? be possible to avoid this by skipping rank-checking/adjustment when prediction is being done?)
