### PR TITLE
update 'deviance' to '-2*log(L)' in output

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -2068,7 +2068,7 @@ llikAIC <- function(object) {
     llik <- logLik(object)
     AICstats <-
         c(AIC = AIC(llik), BIC = BIC(llik), logLik = c(llik),
-          deviance = -2*llik, ## FIXME:
+          `-2*log(L)` = -2*llik,
           df.resid = df.residual(object))
     list(logLik = llik, AICtab = AICstats)
 }

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -697,8 +697,7 @@ print.glmmTMB <-
   ## Type Of Model fit --- REML? ---['class']  & Family & Call
   .prt.call.glmmTMB(x$call, long=longCall)
   ## the 'digits' argument should have an action here
-  aictab <- c(AIC = AIC(x), BIC = BIC(x), logLik = logLik(x),
-              df.resid = df.residual(x))
+  aictab <- llikAIC(x)$AICtab
   .prt.aictab(aictab, digits=digits+1)
   ## varcorr
   if (!all(sapply(vc <- VarCorr(x),is.null))) {

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -35,6 +35,14 @@
       (GH #1133, @strengejacke)
     } % itemize
   } % bug fixes
+  \subsection{USER-VISIBLE CHANGES}{
+    \itemize{
+      \item headline of \code{print} and \code{summary} output
+      now labels the minimum of the objective function
+      (correctly) as "-2*log(L)" rather than "deviance" (GH #1156, @ladin100)
+    } % itemize
+  } % user-visible changes
+
 } % 1.1.11
   
 \section{CHANGES IN VERSION 1.1.10  (2024-09-26)}{


### PR DESCRIPTION
see #1156 

headline now looks like this (fourth element labeled "-2*log(L)" instead of "deviance")

```
      AIC       BIC    logLik -2*log(L)  df.resid 
 35026.72  35059.50 -17508.36  35016.72      5195 
```