### PR TITLE
Rankdef pred

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -303,7 +303,7 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
     }
 
     ## fixme: may need to modify here, or modify getXReTrms, for smooth-term prediction
-    condList  <- getXReTrms(formula, mf, fr, type="coNditional", contrasts=contrasts, sparse=sparseX[["cond"]],
+    condList  <- getXReTrms(formula, mf, fr, type="conditional", contrasts=contrasts, sparse=sparseX[["cond"]],
                             old_smooths = old_smooths$cond)
     ziList    <- getXReTrms(ziformula, mf, fr, type="zero-inflation", contrasts=contrasts, sparse=sparseX[["zi"]],
                             old_smooths = old_smooths$zi)

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -839,10 +839,10 @@ getXReTrms <- function(formula, mf, fr, ranOK=TRUE, type="",
         ## HACK: should duplicate 'homdiag' definition, keep it as 's' (or call it 'mgcv_smooth")
         ##  so we can recognize it.
         ## Here, we're using the fact that the ...AddArgs stuff is still in an unevaluated form
-        reXterms <- Map(function(f, a) {
-            if (identical(head(a), as.symbol('s'))) NA else termsfun(f)
-        }, ss$reTrmFormulas, ss$reTrmAddArgs)
-        
+        drop_s <- function(f, a) {
+            if (identical(a[[1]], as.symbol('s'))) NA else termsfun(f)
+        }
+        reXterms <- Map(drop_s, ss$reTrmFormulas, ss$reTrmAddArgs)
         
         for (i in seq_along(ss$reTrmAddArgs)) {
           if(ss$reTrmClasses[i] == "rr") {

--- a/glmmTMB/R/predict.R
+++ b/glmmTMB/R/predict.R
@@ -423,8 +423,11 @@ predict.glmmTMB <- function(object,
       xnm <- paste0("X", nm)
       betanm <- paste0("beta", nm)
       X <- getME(object, xnm)
-      if (prod(dim(X)) > 0 && !is.null(dd <- attr(X, "col.dropped"))) {
-        if (is(X, "Matrix")) xnm <- paste0(xnm, "S")
+      has_dropped <- prod(dim(X)) > 0 && !is.null(dd <- attr(X, "col.dropped"))
+      if (is(X, "Matrix")) xnm <- paste0(xnm, "S")
+      newX <- TMBStruc$data.tmb[[xnm]]
+      already_dropped <- ncol(newX) == ncol(X) && !any(names(dd) %in% colnames(newX))
+      if (has_dropped && !already_dropped) {
         TMBStruc$data.tmb[[xnm]] <- TMBStruc$data.tmb[[xnm]][,-dd]
         TMBStruc$parameters[[betanm]] <- TMBStruc$parameters[[betanm]][-dd]
       }

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -15,6 +15,8 @@
       TRUE (GH#1189, @fisher-j)
       \item implementation of \code{hetar1} covstruct was wrong, fixed now
       (GH #1204, Daniel Sabanés Bové and Nik Krieger)
+      \item prediction on rank-deficient X matrices could throw a false
+      positive error (Erin McCallum, \url{https://stackoverflow.com/q/77517125/190277})
     }
   } % bug fixes
   \subsection{NEW FEATURES}{


### PR DESCRIPTION
Fixes problem reported in https://stackoverflow.com/q/77517125/190277  (rank-deficient columns were breaking prediction machinery because we attempted to drop them even though they get dropped in a preceding step)

Incidentally also fixes a problem caused by the development version of `reformulas` (no longer exports a `head.language` method ...
