### PR TITLE
Add indisting covariance structure for indistinguishable dyads

### DIFF
--- a/glmmTMB/R/enum.R
+++ b/glmmTMB/R/enum.R
@@ -49,7 +49,8 @@
   hetar1 = 12,
   homcs = 13,
   homtoep = 14,
-  equalto = 15
+  equalto = 15,
+  indisting = 16
 )
 .valid_zipredictcode <- c(
   corrected = 0,

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -434,8 +434,8 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
     ## add X matrices, prior info
     data.tmb <- c(data.tmb, Xlist, prior_struc)
 
-  ## identify covariance structures that have non-default theta values
-  ndThetaStruc <- function(lst) any(lst$ss %in% c("rr", "propto", "equalto"))
+  # function to set value for dorr
+  rrVal <- function(lst) if(any(lst$ss == "rr") || any(lst$ss == "propto") || any(lst$ss == "equalto")) 1 else 0
 
   getVal <- function(obj, component)
     vapply(obj, function(x) x[[component]], numeric(1))
@@ -458,12 +458,12 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
 
   # theta is 0, 1 for rr_covstruct
   # theta is parameterised to corr matrix for propto
-  t01 <- function(ndTheta, ReStruc, List = NULL){
+  t01 <- function(dorr, ReStruc, List = NULL){
 
     nt <- sum(getVal(ReStruc, "blockNumTheta"))
     theta <- rr0(nt)
     
-    if (ndTheta) {
+    if (dorr) {
       blockNumTheta <- getVal(ReStruc,"blockNumTheta")
       blockCode  <- getVal(ReStruc, "blockCode")
       thetaseq <- rep.int(seq_along(blockNumTheta), blockNumTheta)
@@ -495,9 +495,9 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
                        b       = rep(beta_init, ncol(Z)),
                        bzi     = rr0(ncol(Zzi)),                       
                        bdisp   = rep(betadisp_init, ncol(Zdisp)),
-                       theta   = t01(ndTheta = ndThetaStruc(condList), condReStruc, condList),
-                       thetazi = t01(ndTheta = ndThetaStruc(ziList), ziReStruc, ziList),                       
-                       thetadisp = t01(ndTheta = ndThetaStruc(dispList), dispReStruc, dispList),
+                       theta   = t01(dorr = rrVal(condList), condReStruc, condList),
+                       thetazi = t01(dorr = rrVal(ziList), ziReStruc, ziList),                       
+                       thetadisp = t01(dorr = rrVal(dispList), dispReStruc, dispList),
                        psi  = psi_init
                      ))
 
@@ -517,14 +517,13 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
                               start_method = control$start_method)
   }
 
-  
   ### Change mapping for propto 
   for (component in c("cond", "zi", "disp")) {
     rList <- get(paste0(component, "List"))
-    if(length(rList$ss) > 0 && any(rList$ss %in% c("propto", "equalto") )){
-      restruccomp <- get(paste0(component, "ReStruc"))
+    if(rrVal(rList)){
+      restruc <- get(paste0(component, "ReStruc"))
       mapArg.orig <- mapArg
-      mapArg <- map.theta.propto(restruccomp, mapArg.orig, component)
+      mapArg <- map.theta.propto(restruc, mapArg.orig, component)
     }
   }
 
@@ -1043,10 +1042,89 @@ getReStruc <- function(reTrms, ss=NULL, aa=NULL, reXterms=NULL, fr=NULL, full_co
                "homcs" = 2,
                "homtoep" = blksize,
                "equalto" = blksize * (blksize+1) / 2, #equalto (same as us)
+               "indisting" = {
+                 if (blksize %% 2 != 0)
+                   stop("indisting() requires an even number of random effect terms")
+                 blksize/2 + (blksize/2)^2
+               },
                stop(sprintf("undefined number of parameters for covstruct '%s'", struc))
                )
     }
     blockNumTheta <- mapply(parFun, ss, blksize, blkrank, SIMPLIFY=FALSE)
+    # --- Validate indisting column ordering ---
+    check_indisting_order <- function(cnms, group = "group") {
+      is_bare   <- !grepl(":", cnms)
+      persons   <- cnms[is_bare]
+      n_persons <- length(persons)
+      if (n_persons < 2)
+        stop("indisting() requires at least 2 person indicator terms (e.g. P1 and P2)")
+      get_vartype <- function(nm) {
+        if (nm %in% persons) return("")
+        for (p in persons) {
+          nm <- gsub(paste0("^", p, ":"), "", nm)
+          nm <- gsub(paste0(":", p, "$"), "", nm)
+        }
+        nm
+      }
+      get_person <- function(nm) {
+        if (nm %in% persons) return(nm)
+        for (p in persons) {
+          if (grepl(paste0("^", p, ":"), nm) || grepl(paste0(":", p, "$"), nm))
+            return(p)
+        }
+        return(NA)
+      }
+      vartypes     <- sapply(cnms, get_vartype)
+      person_ids   <- sapply(cnms, get_person)
+      unique_types <- unique(vartypes)
+      for (vt in unique_types) {
+        idx <- which(vartypes == vt)
+        if (length(idx) != n_persons)
+          stop(sprintf(
+            "indisting(): variable type '%s' appears %d time(s) but should appear %d time(s) -- once for each person indicator (%s).",
+            vt, length(idx), n_persons, paste(persons, collapse = ", ")))
+        if (!all(diff(idx) == 1)) {
+          correct_terms <- c(persons)
+          for (other_vt in unique_types[unique_types != ""])
+            for (p in persons)
+              correct_terms <- c(correct_terms, paste(p, other_vt, sep = ":"))
+          correct_formula <- paste("indisting(0 +",
+                                   paste(correct_terms, collapse = " + "),
+                                   "|", group, ")")
+          stop(paste0(
+            "indisting() requires like-variable terms to be adjacent in the formula.\n",
+            "  Variable type '", vt, "' is not grouped consecutively.\n",
+            "  The correct ordering for your terms would be:\n",
+            "  ", correct_formula))
+        }
+        if (vt != "") {
+          person_order_in_group <- unname(person_ids[idx])
+          if (!identical(person_order_in_group, persons)) {
+            correct_terms <- c(persons)
+            for (other_vt in unique_types[unique_types != ""])
+              for (p in persons)
+                correct_terms <- c(correct_terms, paste(p, other_vt, sep = ":"))
+            correct_formula <- paste("indisting(0 +",
+                                     paste(correct_terms, collapse = " + "),
+                                     "|", group, ")")
+            stop(paste0(
+              "indisting() requires consistent person ordering across all variable types.\n",
+              "  For variable type '", vt, "', persons appear in order: ",
+              paste(person_order_in_group, collapse = ", "), "\n",
+              "  but the expected order is: ",
+              paste(persons, collapse = ", "), "\n",
+              "  The correct ordering for your terms would be:\n",
+              "  ", correct_formula))
+          }
+        }
+      }
+      invisible(TRUE)
+    }
+    for (i in seq_along(ss)) {
+      if (ss[[i]] == "indisting") {
+        check_indisting_order(reTrms$cnms[[i]], names(reTrms$cnms)[i])
+      }
+    }
 
     covCode <- .valid_covstruct[ss]
 
@@ -1355,7 +1433,7 @@ glmmTMB <- function(
                names(mf), 0L)
     ## FIXME: could break if formula is not specified first ???
     mf <- mf[c(1L, m)]
-    mf$drop.unused.levels <- control$drop_unused_levels
+    mf$drop.unused.levels <- TRUE
     mf[[1]] <- as.name("model.frame")
     mf$data <- data ## propagate ..offset modification?
 
@@ -1516,7 +1594,6 @@ glmmTMB <- function(
 ##' @param rank_check Check whether all parameters in fixed-effects models are identifiable? This test may be slow for models with large numbers of fixed-effect parameters, therefore default value is 'warning'. Alternatives include 'skip' (no check), 'stop' (throw an error), and 'adjust' (drop redundant columns from the fixed-effect model matrix).
 ##' @param conv_check Do basic checks of convergence (check for non-positive definite Hessian and non-zero convergence code from optimizer). Default is 'warning'; 'skip' ignores these tests (not recommended for general use!)
 ##' @param full_cor compute full correlation matrices? can be either a length-1 logical vector (TRUE/FALSE) to include full correlation matrices for all or none of the random-effect terms in the model, or a logical vector with length equal to the number of correlation matrices, to include/exclude correlation matrices individually
-##' @param drop_unused_levels drop unused levels in grouping variables?
 ##' @details
 ##' By default, \code{\link{glmmTMB}} uses the nonlinear optimizer
 ##' \code{\link{nlminb}} for parameter estimation. Users may sometimes
@@ -1567,8 +1644,7 @@ glmmTMBControl <- function(optCtrl=NULL,
                            start_method = list(method = NULL, jitter.sd = 0),
                            rank_check = c("adjust", "warning", "stop", "skip"),
                            conv_check = c("warning", "skip"),
-                           full_cor = TRUE,
-                           drop_unused_levels = TRUE) {
+                           full_cor = TRUE) {
 
     if (is.null(optCtrl) && identical(optimizer,nlminb)) {
         optCtrl <- list(iter.max=300, eval.max=400)
@@ -1607,7 +1683,7 @@ glmmTMBControl <- function(optCtrl=NULL,
     ## (TMB tweedie derivatives currently slow)
     namedList(optCtrl, profile, collect, parallel, optimizer, optArgs,
               eigval_check, zerodisp_val, start_method, rank_check, conv_check,
-              full_cor, drop_unused_levels)
+              full_cor)
 }
 
 ##' collapse duplicated observations

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -434,8 +434,8 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
     ## add X matrices, prior info
     data.tmb <- c(data.tmb, Xlist, prior_struc)
 
-  # function to set value for dorr
-  rrVal <- function(lst) if(any(lst$ss == "rr") || any(lst$ss == "propto") || any(lst$ss == "equalto")) 1 else 0
+  ## identify covariance structures that have non-default theta values
+  ndThetaStruc <- function(lst) any(lst$ss %in% c("rr", "propto", "equalto"))
 
   getVal <- function(obj, component)
     vapply(obj, function(x) x[[component]], numeric(1))
@@ -458,12 +458,12 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
 
   # theta is 0, 1 for rr_covstruct
   # theta is parameterised to corr matrix for propto
-  t01 <- function(dorr, ReStruc, List = NULL){
+  t01 <- function(ndTheta, ReStruc, List = NULL){
 
     nt <- sum(getVal(ReStruc, "blockNumTheta"))
     theta <- rr0(nt)
     
-    if (dorr) {
+    if (ndTheta) {
       blockNumTheta <- getVal(ReStruc,"blockNumTheta")
       blockCode  <- getVal(ReStruc, "blockCode")
       thetaseq <- rep.int(seq_along(blockNumTheta), blockNumTheta)
@@ -495,9 +495,9 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
                        b       = rep(beta_init, ncol(Z)),
                        bzi     = rr0(ncol(Zzi)),                       
                        bdisp   = rep(betadisp_init, ncol(Zdisp)),
-                       theta   = t01(dorr = rrVal(condList), condReStruc, condList),
-                       thetazi = t01(dorr = rrVal(ziList), ziReStruc, ziList),                       
-                       thetadisp = t01(dorr = rrVal(dispList), dispReStruc, dispList),
+                       theta   = t01(ndTheta = ndThetaStruc(condList), condReStruc, condList),
+                       thetazi = t01(ndTheta = ndThetaStruc(ziList), ziReStruc, ziList),                       
+                       thetadisp = t01(ndTheta = ndThetaStruc(dispList), dispReStruc, dispList),
                        psi  = psi_init
                      ))
 
@@ -517,13 +517,14 @@ mkTMBStruc <- function(formula, ziformula, dispformula,
                               start_method = control$start_method)
   }
 
+  
   ### Change mapping for propto 
   for (component in c("cond", "zi", "disp")) {
     rList <- get(paste0(component, "List"))
-    if(rrVal(rList)){
-      restruc <- get(paste0(component, "ReStruc"))
+    if(length(rList$ss) > 0 && any(rList$ss %in% c("propto", "equalto") )){
+      restruccomp <- get(paste0(component, "ReStruc"))
       mapArg.orig <- mapArg
-      mapArg <- map.theta.propto(restruc, mapArg.orig, component)
+      mapArg <- map.theta.propto(restruccomp, mapArg.orig, component)
     }
   }
 
@@ -1433,7 +1434,7 @@ glmmTMB <- function(
                names(mf), 0L)
     ## FIXME: could break if formula is not specified first ???
     mf <- mf[c(1L, m)]
-    mf$drop.unused.levels <- TRUE
+    mf$drop.unused.levels <- control$drop_unused_levels
     mf[[1]] <- as.name("model.frame")
     mf$data <- data ## propagate ..offset modification?
 
@@ -1594,6 +1595,7 @@ glmmTMB <- function(
 ##' @param rank_check Check whether all parameters in fixed-effects models are identifiable? This test may be slow for models with large numbers of fixed-effect parameters, therefore default value is 'warning'. Alternatives include 'skip' (no check), 'stop' (throw an error), and 'adjust' (drop redundant columns from the fixed-effect model matrix).
 ##' @param conv_check Do basic checks of convergence (check for non-positive definite Hessian and non-zero convergence code from optimizer). Default is 'warning'; 'skip' ignores these tests (not recommended for general use!)
 ##' @param full_cor compute full correlation matrices? can be either a length-1 logical vector (TRUE/FALSE) to include full correlation matrices for all or none of the random-effect terms in the model, or a logical vector with length equal to the number of correlation matrices, to include/exclude correlation matrices individually
+##' @param drop_unused_levels drop unused levels in grouping variables?
 ##' @details
 ##' By default, \code{\link{glmmTMB}} uses the nonlinear optimizer
 ##' \code{\link{nlminb}} for parameter estimation. Users may sometimes
@@ -1644,7 +1646,8 @@ glmmTMBControl <- function(optCtrl=NULL,
                            start_method = list(method = NULL, jitter.sd = 0),
                            rank_check = c("adjust", "warning", "stop", "skip"),
                            conv_check = c("warning", "skip"),
-                           full_cor = TRUE) {
+                           full_cor = TRUE,
+                           drop_unused_levels = TRUE) {
 
     if (is.null(optCtrl) && identical(optimizer,nlminb)) {
         optCtrl <- list(iter.max=300, eval.max=400)
@@ -1683,7 +1686,7 @@ glmmTMBControl <- function(optCtrl=NULL,
     ## (TMB tweedie derivatives currently slow)
     namedList(optCtrl, profile, collect, parallel, optimizer, optArgs,
               eigval_check, zerodisp_val, start_method, rank_check, conv_check,
-              full_cor)
+              full_cor, drop_unused_levels)
 }
 
 ##' collapse duplicated observations

--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -1044,88 +1044,13 @@ getReStruc <- function(reTrms, ss=NULL, aa=NULL, reXterms=NULL, fr=NULL, full_co
                "homtoep" = blksize,
                "equalto" = blksize * (blksize+1) / 2, #equalto (same as us)
                "indisting" = {
-                 if (blksize %% 2 != 0)
-                   stop("indisting() requires an even number of random effect terms")
-                 blksize/2 + (blksize/2)^2
+                 k_ind <- blksize / 2
+                 k_ind + k_ind^2
                },
                stop(sprintf("undefined number of parameters for covstruct '%s'", struc))
                )
     }
     blockNumTheta <- mapply(parFun, ss, blksize, blkrank, SIMPLIFY=FALSE)
-    # --- Validate indisting column ordering ---
-    check_indisting_order <- function(cnms, group = "group") {
-      is_bare   <- !grepl(":", cnms)
-      persons   <- cnms[is_bare]
-      n_persons <- length(persons)
-      if (n_persons < 2)
-        stop("indisting() requires at least 2 person indicator terms (e.g. P1 and P2)")
-      get_vartype <- function(nm) {
-        if (nm %in% persons) return("")
-        for (p in persons) {
-          nm <- gsub(paste0("^", p, ":"), "", nm)
-          nm <- gsub(paste0(":", p, "$"), "", nm)
-        }
-        nm
-      }
-      get_person <- function(nm) {
-        if (nm %in% persons) return(nm)
-        for (p in persons) {
-          if (grepl(paste0("^", p, ":"), nm) || grepl(paste0(":", p, "$"), nm))
-            return(p)
-        }
-        return(NA)
-      }
-      vartypes     <- sapply(cnms, get_vartype)
-      person_ids   <- sapply(cnms, get_person)
-      unique_types <- unique(vartypes)
-      for (vt in unique_types) {
-        idx <- which(vartypes == vt)
-        if (length(idx) != n_persons)
-          stop(sprintf(
-            "indisting(): variable type '%s' appears %d time(s) but should appear %d time(s) -- once for each person indicator (%s).",
-            vt, length(idx), n_persons, paste(persons, collapse = ", ")))
-        if (!all(diff(idx) == 1)) {
-          correct_terms <- c(persons)
-          for (other_vt in unique_types[unique_types != ""])
-            for (p in persons)
-              correct_terms <- c(correct_terms, paste(p, other_vt, sep = ":"))
-          correct_formula <- paste("indisting(0 +",
-                                   paste(correct_terms, collapse = " + "),
-                                   "|", group, ")")
-          stop(paste0(
-            "indisting() requires like-variable terms to be adjacent in the formula.\n",
-            "  Variable type '", vt, "' is not grouped consecutively.\n",
-            "  The correct ordering for your terms would be:\n",
-            "  ", correct_formula))
-        }
-        if (vt != "") {
-          person_order_in_group <- unname(person_ids[idx])
-          if (!identical(person_order_in_group, persons)) {
-            correct_terms <- c(persons)
-            for (other_vt in unique_types[unique_types != ""])
-              for (p in persons)
-                correct_terms <- c(correct_terms, paste(p, other_vt, sep = ":"))
-            correct_formula <- paste("indisting(0 +",
-                                     paste(correct_terms, collapse = " + "),
-                                     "|", group, ")")
-            stop(paste0(
-              "indisting() requires consistent person ordering across all variable types.\n",
-              "  For variable type '", vt, "', persons appear in order: ",
-              paste(person_order_in_group, collapse = ", "), "\n",
-              "  but the expected order is: ",
-              paste(persons, collapse = ", "), "\n",
-              "  The correct ordering for your terms would be:\n",
-              "  ", correct_formula))
-          }
-        }
-      }
-      invisible(TRUE)
-    }
-    for (i in seq_along(ss)) {
-      if (ss[[i]] == "indisting") {
-        check_indisting_order(reTrms$cnms[[i]], names(reTrms$cnms)[i])
-      }
-    }
 
     covCode <- .valid_covstruct[ss]
 
@@ -1405,6 +1330,65 @@ glmmTMB <- function(
     # substitute evaluated versions
     ## FIXME: denv leftover from lme4, not defined yet
 
+  validate_indisting <- function(formula, data) {
+    parsed <- reformulas::splitForm(formula, allowFixedOnly = FALSE,
+                                    specials = names(.valid_covstruct))
+    for (i in seq_along(parsed$reTrmClasses)) {
+      if (parsed$reTrmClasses[i] != "indisting") next
+      re_formula <- parsed$reTrmFormulas[[i]]
+      group_var  <- deparse(re_formula[[3]])
+      re_lhs     <- re_formula[[2]]
+      lhs_str    <- gsub("\\s+", " ",
+                         paste(deparse(re_lhs), collapse = ""))
+      lhs_terms  <- terms(as.formula(paste("~", lhs_str)))
+      if (attr(lhs_terms, "intercept") == 1)
+        stop(paste0(
+          "indisting(): formula must not include an intercept.\n",
+          "Use: indisting(0 + memberVar + memberVar:x | ", group_var, ")",
+          "\nwhere memberVar is a factor variable with exactly 2 levels."
+        ))
+      re_terms <- attr(lhs_terms, "term.labels")
+      if (length(re_terms) == 0)
+        stop(paste0(
+          "indisting(): formula has no terms.\n",
+          "Use: indisting(0 + memberVar + memberVar:x | ", group_var, ")",
+          "\nwhere memberVar is a factor variable with exactly 2 levels."
+        ))
+      member_var <- re_terms[1]
+      if (!member_var %in% names(data))
+        stop(paste0(
+          "indisting(): first term \"", member_var, "\" not found in data.\n",
+          "Use: indisting(0 + memberVar + memberVar:x | ", group_var, ")",
+          "\nwhere memberVar is a factor variable with exactly 2 levels."
+        ))
+      if (!is.factor(data[[member_var]]))
+        stop(paste0(
+          "indisting(): \"", member_var, "\" must be a factor variable.\n",
+          "Use: indisting(0 + memberVar + memberVar:x | ", group_var, ")",
+          "\nwhere memberVar is a factor variable with exactly 2 levels."
+        ))
+      if (nlevels(data[[member_var]]) != 2L)
+        stop(paste0(
+          "indisting(): \"", member_var, "\" must have exactly 2 levels.\n",
+          "Use: indisting(0 + memberVar + memberVar:x | ", group_var, ")",
+          "\nwhere memberVar is a factor variable with exactly 2 levels."
+        ))
+      if (length(re_terms) > 1) {
+        slope_terms <- re_terms[-1]
+        bad <- slope_terms[!grepl(paste0("^", member_var, ":"), slope_terms)]
+        if (length(bad) > 0)
+          stop(paste0(
+            "indisting(): all slope terms must interact with \"",
+            member_var, "\".\n",
+            "Unexpected terms: ", paste(bad, collapse = ", "), ".\n",
+            "Use: indisting(0 + ", member_var, " + ",
+            member_var, ":x | ", group_var, ")"
+          ))
+      }
+    }
+    invisible(NULL)
+  }
+  if (!is.null(data)) validate_indisting(formula, data)
     environment(formula) <- parent.frame()
     call$formula <- mc$formula <- formula
     ## add offset-specified-as-argument to formula as + offset(...)

--- a/glmmTMB/src/glmmTMB.cpp
+++ b/glmmTMB/src/glmmTMB.cpp
@@ -94,7 +94,8 @@ enum valid_covStruct {
   hetar1_covstruct = 12,
   homcs_covstruct = 13,
   homtoep_covstruct = 14,
-  equalto_covstruct = 15
+  equalto_covstruct = 15,
+  indisting_covstruct = 16
 };
 
 // should probably be named just 'predictCode';
@@ -795,6 +796,95 @@ Type termwise_nll(array<Type> &U, vector<Type> theta, per_term_info<Type>& term,
     }
     term.corr = nldens.cov(); // For report
     term.sd = sd;             // For report
+  }
+  else if (term.blockCode == indisting_covstruct){
+    {  // inner scope: isolate all variable declarations from adjacent blocks
+    // Indistinguishable dyads covariance structure.
+    // For indistinguishable dyads where the two members are exchangeable.
+    // n = blockSize (must be even), k = n/2 variable types per person.
+    //
+    // Variables must be ordered in the formula as:
+    //   P1_v1, P2_v1, P1_v2, P2_v2, ..., P1_vk, P2_vk
+    //
+    // theta layout (total = k*(k+1) parameters):
+    //   theta(0)...theta(k-1)              : k unique log-SDs
+    //                                        (P1_vi and P2_vi share the same SD)
+    //   theta(k)...theta(2k-1)             : k partner correlations
+    //                                        Cor(P1_vi, P2_vi) for i=0..k-1
+    //   theta(2k)...theta(2k+C(k,2)-1)    : C(k,2) within-person cross-type correlations
+    //                                        Cor(P1_vi, P1_vj) = Cor(P2_vi, P2_vj), j>i
+    //   theta(2k+C(k,2))...theta(k^2+k-1) : C(k,2) cross-person cross-type correlations
+    //                                        Cor(P1_vi, P2_vj) = Cor(P2_vi, P1_vj), j>i
+    //
+    // Correlations are encoded via the signed-ratio transform r = x/sqrt(1+x^2),
+    // matching glmmTMB's internal convention for correlation parameters.
+    //
+    // The constrained covariance matrix Sigma = D*R*D (where D = diag(sd_id))
+    // is passed directly to MVNORM_t, following the cs structure approach.
+    // Matrix inversion happens internally inside MVNORM_t, only once.
+    // Backstop check: odd blockSize should already be caught at the R level.
+    if (term.blockSize % 2 != 0) {
+      Rf_error("indisting() requires an even number of random effect terms");
+    }
+    int n_id   = term.blockSize;
+    int k_id   = n_id / 2;
+    int ck2_id = k_id * (k_id - 1) / 2;  // C(k,2)
+    // --- Expand k unique log-SDs to n (each variable pair shares one SD) ---
+    vector<Type> sd_id(n_id);
+    for (int i = 0; i < k_id; i++) {
+      sd_id(2*i)     = exp(theta(i));
+      sd_id(2*i + 1) = exp(theta(i));
+    }
+    // --- Offsets into theta for each correlation block ---
+    int off_partner_id = k_id;
+    int off_wp_id      = k_id + k_id;
+    int off_cp_id      = k_id + k_id + ck2_id;
+    // Signed-ratio encoding: r = x / sqrt(1 + x^2)
+#define SR(x) ((x) / sqrt(Type(1) + (x)*(x)))
+    // --- Build constrained correlation matrix R_id ---
+    matrix<Type> R_id(n_id, n_id);
+    R_id.setZero();
+    for (int i = 0; i < n_id; i++) R_id(i, i) = Type(1);
+    // Partner correlations: Cor(P1_vi, P2_vi)
+    for (int i = 0; i < k_id; i++) {
+      Type r = SR(theta(off_partner_id + i));
+      R_id(2*i,     2*i + 1) = r;
+      R_id(2*i + 1, 2*i)     = r;
+    }
+    // Cross-type correlations for each pair of variable types i < j
+    {
+      int pair_id = 0;
+      for (int i = 0; i < k_id; i++) {
+        for (int j = i + 1; j < k_id; j++, pair_id++) {
+          Type rw = SR(theta(off_wp_id + pair_id));  // within-person
+          Type rc = SR(theta(off_cp_id + pair_id));  // cross-person
+          // Within: Cor(P1_vi, P1_vj) = Cor(P2_vi, P2_vj) = rw
+          R_id(2*i,     2*j)     = rw;  R_id(2*j,     2*i)     = rw;
+          R_id(2*i + 1, 2*j + 1) = rw;  R_id(2*j + 1, 2*i + 1) = rw;
+          // Cross: Cor(P1_vi, P2_vj) = Cor(P2_vi, P1_vj) = rc
+          R_id(2*i,     2*j + 1) = rc;  R_id(2*j + 1, 2*i)     = rc;
+          R_id(2*i + 1, 2*j)     = rc;  R_id(2*j,     2*i + 1) = rc;
+        }
+      }
+    }
+#undef SR
+    // --- Build covariance matrix Sigma = D * R * D where D = diag(sd_id) ---
+    matrix<Type> Sigma_id(n_id, n_id);
+    for (int i = 0; i < n_id; i++)
+      for (int j = 0; j < n_id; j++)
+        Sigma_id(i, j) = sd_id(i) * R_id(i, j) * sd_id(j);
+    // --- Pass directly to MVNORM_t, following the cs structure approach ---
+    // Matrix inversion happens internally inside MVNORM_t, only once.
+    density::MVNORM_t<Type> nldens(Sigma_id);
+    for (int i = 0; i < term.blockReps; i++) {
+      ans += nldens(U.col(i));
+      if (do_simulate) {
+        U.col(i) = nldens.simulate();
+      }
+    }
+    if (term.fullCor == 1) term.corr = R_id;
+    term.sd = sd_id;
+    }  // end inner scope
   }
   else error("covStruct not implemented!");
   return ans;

--- a/glmmTMB/src/glmmTMB.cpp
+++ b/glmmTMB/src/glmmTMB.cpp
@@ -797,94 +797,93 @@ Type termwise_nll(array<Type> &U, vector<Type> theta, per_term_info<Type>& term,
     term.corr = nldens.cov(); // For report
     term.sd = sd;             // For report
   }
-  else if (term.blockCode == indisting_covstruct){
-    {  // inner scope: isolate all variable declarations from adjacent blocks
-    // Indistinguishable dyads covariance structure.
-    // For indistinguishable dyads where the two members are exchangeable.
-    // n = blockSize (must be even), k = n/2 variable types per person.
-    //
-    // Variables must be ordered in the formula as:
-    //   P1_v1, P2_v1, P1_v2, P2_v2, ..., P1_vk, P2_vk
-    //
-    // theta layout (total = k*(k+1) parameters):
-    //   theta(0)...theta(k-1)              : k unique log-SDs
-    //                                        (P1_vi and P2_vi share the same SD)
-    //   theta(k)...theta(2k-1)             : k partner correlations
-    //                                        Cor(P1_vi, P2_vi) for i=0..k-1
-    //   theta(2k)...theta(2k+C(k,2)-1)    : C(k,2) within-person cross-type correlations
-    //                                        Cor(P1_vi, P1_vj) = Cor(P2_vi, P2_vj), j>i
-    //   theta(2k+C(k,2))...theta(k^2+k-1) : C(k,2) cross-person cross-type correlations
-    //                                        Cor(P1_vi, P2_vj) = Cor(P2_vi, P1_vj), j>i
-    //
-    // Correlations are encoded via the signed-ratio transform r = x/sqrt(1+x^2),
-    // matching glmmTMB's internal convention for correlation parameters.
-    //
-    // The constrained covariance matrix Sigma = D*R*D (where D = diag(sd_id))
-    // is passed directly to MVNORM_t, following the cs structure approach.
-    // Matrix inversion happens internally inside MVNORM_t, only once.
-    // Backstop check: odd blockSize should already be caught at the R level.
-    if (term.blockSize % 2 != 0) {
-      Rf_error("indisting() requires an even number of random effect terms");
-    }
+  else if (term.blockCode == indisting_covstruct) {
+    // Indistinguishable dyads: sum-and-difference block decomposition.
+    // R (2k x 2k) is PD iff S (k x k) and D (k x k) are both PD.
+    // S = diag(sqrt(a)) * R_S * diag(sqrt(a)),  a_i = 1 + rho_p_i
+    // D = diag(sqrt(b)) * R_D * diag(sqrt(b)),  b_i = 1 - rho_p_i
+    // R_S, R_D parameterized via UNSTRUCTURED_CORR_t (PD by construction).
+    // Partner correlations: rho_p_i = 2 * invlogit(theta_i) - 1.
     int n_id   = term.blockSize;
     int k_id   = n_id / 2;
-    int ck2_id = k_id * (k_id - 1) / 2;  // C(k,2)
-    // --- Expand k unique log-SDs to n (each variable pair shares one SD) ---
+    int ck2_id = k_id * (k_id - 1) / 2;
+    // log-SDs: k unique SDs shared within each variable type
     vector<Type> sd_id(n_id);
     for (int i = 0; i < k_id; i++) {
       sd_id(2*i)     = exp(theta(i));
       sd_id(2*i + 1) = exp(theta(i));
     }
-    // --- Offsets into theta for each correlation block ---
-    int off_partner_id = k_id;
-    int off_wp_id      = k_id + k_id;
-    int off_cp_id      = k_id + k_id + ck2_id;
-    // Signed-ratio encoding: r = x / sqrt(1 + x^2)
-#define SR(x) ((x) / sqrt(Type(1) + (x)*(x)))
-    // --- Build constrained correlation matrix R_id ---
+    // Partner correlations via invlogit: rho_p_i in (-1, 1)
+    vector<Type> rho_p(k_id);
+    for (int i = 0; i < k_id; i++)
+      rho_p(i) = Type(2) * invlogit(theta(k_id + i)) - Type(1);
+    // Diagonal entries of S and D
+    vector<Type> a_id(k_id), b_id(k_id);
+    for (int i = 0; i < k_id; i++) {
+      a_id(i) = Type(1) + rho_p(i);
+      b_id(i) = Type(1) - rho_p(i);
+    }
+    // R_S: k x k correlation matrix via UNSTRUCTURED_CORR_t
+    vector<Type> theta_S(ck2_id);
+    for (int i = 0; i < ck2_id; i++)
+      theta_S(i) = theta(2 * k_id + i);
+    matrix<Type> R_S(k_id, k_id);
+    if (ck2_id > 0) {
+      density::UNSTRUCTURED_CORR_t<Type> R_S_dens(theta_S);
+      R_S = R_S_dens.cov();
+    } else {
+      R_S.setZero(); R_S(0,0) = Type(1);
+    }
+    // R_D: k x k correlation matrix via UNSTRUCTURED_CORR_t
+    vector<Type> theta_D(ck2_id);
+    for (int i = 0; i < ck2_id; i++)
+      theta_D(i) = theta(2 * k_id + ck2_id + i);
+    matrix<Type> R_D(k_id, k_id);
+    if (ck2_id > 0) {
+      density::UNSTRUCTURED_CORR_t<Type> R_D_dens(theta_D);
+      R_D = R_D_dens.cov();
+    } else {
+      R_D.setZero(); R_D(0,0) = Type(1);
+    }
+    // S and D blocks
+    matrix<Type> S_id(k_id, k_id);
+    matrix<Type> D_id(k_id, k_id);
+    for (int i = 0; i < k_id; i++)
+      for (int j = 0; j < k_id; j++) {
+        S_id(i,j) = sqrt(a_id(i)) * R_S(i,j) * sqrt(a_id(j));
+        D_id(i,j) = sqrt(b_id(i)) * R_D(i,j) * sqrt(b_id(j));
+      }
+    // Full 2k x 2k correlation matrix
+    // rho_w = (S_ij + D_ij) / 2,  rho_c = (S_ij - D_ij) / 2
     matrix<Type> R_id(n_id, n_id);
     R_id.setZero();
-    for (int i = 0; i < n_id; i++) R_id(i, i) = Type(1);
-    // Partner correlations: Cor(P1_vi, P2_vi)
+    for (int i = 0; i < n_id; i++) R_id(i,i) = Type(1);
     for (int i = 0; i < k_id; i++) {
-      Type r = SR(theta(off_partner_id + i));
-      R_id(2*i,     2*i + 1) = r;
-      R_id(2*i + 1, 2*i)     = r;
+      R_id(2*i, 2*i+1) = rho_p(i);
+      R_id(2*i+1, 2*i) = rho_p(i);
     }
-    // Cross-type correlations for each pair of variable types i < j
-    {
-      int pair_id = 0;
-      for (int i = 0; i < k_id; i++) {
-        for (int j = i + 1; j < k_id; j++, pair_id++) {
-          Type rw = SR(theta(off_wp_id + pair_id));  // within-person
-          Type rc = SR(theta(off_cp_id + pair_id));  // cross-person
-          // Within: Cor(P1_vi, P1_vj) = Cor(P2_vi, P2_vj) = rw
-          R_id(2*i,     2*j)     = rw;  R_id(2*j,     2*i)     = rw;
-          R_id(2*i + 1, 2*j + 1) = rw;  R_id(2*j + 1, 2*i + 1) = rw;
-          // Cross: Cor(P1_vi, P2_vj) = Cor(P2_vi, P1_vj) = rc
-          R_id(2*i,     2*j + 1) = rc;  R_id(2*j + 1, 2*i)     = rc;
-          R_id(2*i + 1, 2*j)     = rc;  R_id(2*j,     2*i + 1) = rc;
-        }
+    for (int i = 0; i < k_id; i++) {
+      for (int j = i+1; j < k_id; j++) {
+        Type rw = (S_id(i,j) + D_id(i,j)) / Type(2);
+        Type rc = (S_id(i,j) - D_id(i,j)) / Type(2);
+        R_id(2*i,   2*j)   = rw;  R_id(2*j,   2*i)   = rw;
+        R_id(2*i+1, 2*j+1) = rw;  R_id(2*j+1, 2*i+1) = rw;
+        R_id(2*i,   2*j+1) = rc;  R_id(2*j+1, 2*i)   = rc;
+        R_id(2*i+1, 2*j)   = rc;  R_id(2*j,   2*i+1) = rc;
       }
     }
-#undef SR
-    // --- Build covariance matrix Sigma = D * R * D where D = diag(sd_id) ---
+    // Covariance matrix and likelihood
     matrix<Type> Sigma_id(n_id, n_id);
     for (int i = 0; i < n_id; i++)
       for (int j = 0; j < n_id; j++)
-        Sigma_id(i, j) = sd_id(i) * R_id(i, j) * sd_id(j);
-    // --- Pass directly to MVNORM_t, following the cs structure approach ---
-    // Matrix inversion happens internally inside MVNORM_t, only once.
+        Sigma_id(i,j) = sd_id(i) * R_id(i,j) * sd_id(j);
     density::MVNORM_t<Type> nldens(Sigma_id);
     for (int i = 0; i < term.blockReps; i++) {
       ans += nldens(U.col(i));
-      if (do_simulate) {
-        U.col(i) = nldens.simulate();
-      }
+      if (do_simulate) U.col(i) = nldens.simulate();
     }
     if (term.fullCor == 1) term.corr = R_id;
     term.sd = sd_id;
-    }  // end inner scope
   }
   else error("covStruct not implemented!");
   return ans;

--- a/glmmTMB/tests/testthat/test-indisting.R
+++ b/glmmTMB/tests/testthat/test-indisting.R
@@ -1,0 +1,56 @@
+stopifnot(require("testthat"),
+          require("glmmTMB"))
+
+data(sleepstudy, package = "lme4")
+
+## Create dyadic structure from sleepstudy.
+## Treat pairs of subjects as dyads (9 dyads, 2 members each, 10 days).
+sleepstudy2 <- sleepstudy
+sleepstudy2$dyad   <- factor(rep(1:9, each = 20))
+sleepstudy2$P1     <- as.integer(as.integer(sleepstudy2$Subject) %% 2 == 1)
+sleepstudy2$P2     <- 1L - sleepstudy2$P1
+sleepstudy2$Days_c <- sleepstudy2$Days - mean(sleepstudy2$Days)
+
+## Fit models once and reuse across tests
+fm_k1 <- suppressWarnings(
+  glmmTMB(Reaction ~ Days +
+            indisting(0 + P1 + P2 | dyad),
+          data = sleepstudy2,
+          REML = TRUE)
+)
+
+fm_k1_homcs <- suppressWarnings(
+  glmmTMB(Reaction ~ Days +
+            homcs(0 + P1 + P2 | dyad),
+          data = sleepstudy2,
+          REML = TRUE)
+)
+
+fm_k2 <- suppressWarnings(
+  glmmTMB(Reaction ~ Days_c +
+            indisting(0 + P1 + P2 + (P1+P2):Days_c | dyad) +
+            homcs(0 + P1 + P2 | dyad:Days),
+          data        = sleepstudy2,
+          dispformula = ~0,
+          REML        = TRUE)
+)
+
+## Extract variance-covariance components once
+vc_k2   <- VarCorr(fm_k2)$cond[[1]]
+sds_k2  <- attr(vc_k2, "stddev")
+cors_k2 <- attr(vc_k2, "correlation")
+
+test_that("indisting k=1: log-likelihood matches homcs", {
+  expect_equal(logLik(fm_k1), logLik(fm_k1_homcs), tolerance = 1e-4)
+})
+
+test_that("indisting k=2 (4x4): symmetry constraints satisfied", {
+  expect_equal(unname(sds_k2[1]), unname(sds_k2[2]), tolerance = 1e-4)
+  expect_equal(unname(sds_k2[3]), unname(sds_k2[4]), tolerance = 1e-4)
+  expect_equal(unname(cors_k2[1, 3]), unname(cors_k2[2, 4]), tolerance = 1e-4)
+  expect_equal(unname(cors_k2[1, 4]), unname(cors_k2[2, 3]), tolerance = 1e-4)
+})
+
+test_that("indisting k=2 (4x4): theta count equals k*(k+1) + 2 homcs = 8", {
+  expect_equal(length(glmmTMB::getME(fm_k2, "theta")), 8L)
+})

--- a/glmmTMB/tests/testthat/test-indisting.R
+++ b/glmmTMB/tests/testthat/test-indisting.R
@@ -5,31 +5,33 @@ data(sleepstudy, package = "lme4")
 
 ## Create dyadic structure from sleepstudy.
 ## Treat pairs of subjects as dyads (9 dyads, 2 members each, 10 days).
-sleepstudy2 <- sleepstudy
+sleepstudy2        <- sleepstudy
 sleepstudy2$dyad   <- factor(rep(1:9, each = 20))
-sleepstudy2$P1     <- as.integer(as.integer(sleepstudy2$Subject) %% 2 == 1)
-sleepstudy2$P2     <- 1L - sleepstudy2$P1
+sleepstudy2$member <- factor(as.integer(as.integer(sleepstudy2$Subject) %% 2) + 1L)
 sleepstudy2$Days_c <- sleepstudy2$Days - mean(sleepstudy2$Days)
+sleepstudy2$Days_f <- factor(sleepstudy2$Days)
 
 ## Fit models once and reuse across tests
 fm_k1 <- suppressWarnings(
   glmmTMB(Reaction ~ Days +
-            indisting(0 + P1 + P2 | dyad),
-          data = sleepstudy2,
-          REML = TRUE)
+            indisting(0 + member | dyad),
+          data        = sleepstudy2,
+          dispformula = ~0,
+          REML        = TRUE)
 )
 
 fm_k1_homcs <- suppressWarnings(
   glmmTMB(Reaction ~ Days +
-            homcs(0 + P1 + P2 | dyad),
-          data = sleepstudy2,
-          REML = TRUE)
+            homcs(0 + member | dyad),
+          data        = sleepstudy2,
+          dispformula = ~0,
+          REML        = TRUE)
 )
 
 fm_k2 <- suppressWarnings(
   glmmTMB(Reaction ~ Days_c +
-            indisting(0 + P1 + P2 + (P1+P2):Days_c | dyad) +
-            homcs(0 + P1 + P2 | dyad:Days),
+            indisting(0 + member + member:Days_c | dyad) +
+            homcs(0 + member | dyad:Days_f),
           data        = sleepstudy2,
           dispformula = ~0,
           REML        = TRUE)
@@ -41,16 +43,41 @@ sds_k2  <- attr(vc_k2, "stddev")
 cors_k2 <- attr(vc_k2, "correlation")
 
 test_that("indisting k=1: log-likelihood matches homcs", {
-  expect_equal(logLik(fm_k1), logLik(fm_k1_homcs), tolerance = 1e-4)
+  expect_equal(as.numeric(logLik(fm_k1)), as.numeric(logLik(fm_k1_homcs)),
+               tolerance = 1e-4)
 })
 
 test_that("indisting k=2 (4x4): symmetry constraints satisfied", {
-  expect_equal(unname(sds_k2[1]), unname(sds_k2[2]), tolerance = 1e-4)
-  expect_equal(unname(sds_k2[3]), unname(sds_k2[4]), tolerance = 1e-4)
-  expect_equal(unname(cors_k2[1, 3]), unname(cors_k2[2, 4]), tolerance = 1e-4)
-  expect_equal(unname(cors_k2[1, 4]), unname(cors_k2[2, 3]), tolerance = 1e-4)
+  expect_equal(unname(sds_k2[1]),    unname(sds_k2[2]),    tolerance = 1e-4)
+  expect_equal(unname(sds_k2[3]),    unname(sds_k2[4]),    tolerance = 1e-4)
+  expect_equal(unname(cors_k2[1,3]), unname(cors_k2[2,4]), tolerance = 1e-4)
+  expect_equal(unname(cors_k2[1,4]), unname(cors_k2[2,3]), tolerance = 1e-4)
 })
 
-test_that("indisting k=2 (4x4): theta count equals k*(k+1) + 2 homcs = 8", {
+test_that("indisting k=2: theta count equals k*(k+1) + 2 homcs = 8", {
   expect_equal(length(glmmTMB::getME(fm_k2, "theta")), 8L)
+})
+
+test_that("indisting: blockCode is 16", {
+  vc <- getFromNamespace(".valid_covstruct", "glmmTMB")
+  expect_equal(unname(vc["indisting"]), 16L)
+})
+
+test_that("indisting: non-factor member variable gives informative error", {
+  sleepstudy2$member_num <- as.integer(sleepstudy2$member)
+  expect_error(
+    glmmTMB(Reaction ~ Days +
+              indisting(0 + member_num + member_num:Days | dyad),
+            data = sleepstudy2, REML = TRUE),
+    "must be a factor variable"
+  )
+})
+
+test_that("indisting: missing intercept suppression gives informative error", {
+  expect_error(
+    glmmTMB(Reaction ~ Days +
+              indisting(member + member:Days | dyad),
+            data = sleepstudy2, REML = TRUE),
+    "must not include an intercept"
+  )
 })

--- a/glmmTMB/vignettes/covstruct.rmd
+++ b/glmmTMB/vignettes/covstruct.rmd
@@ -83,6 +83,7 @@ ctab <- read.delim(sep = "#", comment = "",
  Reduced-rank                     # `rr`          #  $nd-d(d-1)/2$  # rank (d)    # Factor loading matrix (see [Reduced-rank])
  Proportional                       # `propto`      #  $1$            # Variance-covariance matrix # log(proportionality constant)
  Equal                            # `equalto`     #  $0$            # Variance-covariance matrix # -
+Indistinguishable  # `indisting`  #  $n(n+2)/4$  # ordering must be `0 + member + member:x`  # log-SDs ($\theta_1-\theta_{n/2}$); partner correlations $\{2\,\textrm{plogis}(\theta)-1\}$; off-diagonal parameters for sum and difference blocks
 "
 )
 knitr::kable(ctab)
@@ -818,6 +819,66 @@ fit_rma2 <- metafor::rma.mv(yi, vi,
 As with `propto`, we need to specify the random term without an intercept so each column maps to a single effect, and ensure the variance-covariance row/column are ordered as the factor levels of the `id` variable. 
 
 In most meta-analysis applications we want we set the right-hand grouping term `g` to a single level, giving one vector of sampling-error random effects over `id` (one element per effect-size row) with covariance fixed. If `g` has multiple levels, the model creates one such vector per group, treating groups as independent blocks that all share the same variance–covariance matrix.
+
+
+## Indistinguishable
+
+The `indisting()` covariance structure is designed for longitudinal dyadic
+data with indistinguishable or exchangeable members wherein no meaningful
+variable exists on which to tell the two members apart (e.g., same-sex
+couples). Indistinguishability requires that both members have the same
+variance for each random effect and the same within-person covariance(s)
+and between-person covariance(s) between random effects.
+
+Here we use a modified version of the `sleepstudy` data from the `lme4`
+package to provide example usage. With only nine dyads, this example is
+too small for reliable estimation, and is used here for illustration only.
+
+```{r indisting-data, eval=if (exists("params")) params$EVAL else FALSE}
+data(sleepstudy, package = "lme4")
+sleepstudy2        <- sleepstudy
+sleepstudy2$Dyad   <- factor(rep(1:9, each = 20))
+sleepstudy2$member <- factor(as.integer(as.integer(sleepstudy2$Subject) %% 2) + 1L)
+## Add actor and partner lags for stability-and-influence model
+sleepstudy2 <- sleepstudy2[order(sleepstudy2$Dyad, sleepstudy2$member, sleepstudy2$Days), ]
+sleepstudy2$lag_A <- ave(sleepstudy2$Reaction, sleepstudy2$Dyad, sleepstudy2$member,
+                         FUN = function(x) c(NA, x[-length(x)]))
+sleepstudy2$lag_P <- ave(sleepstudy2$lag_A, sleepstudy2$Dyad, sleepstudy2$Days,
+                         FUN = rev)
+sleepstudy2$c_lag_A <- sleepstudy2$lag_A - mean(sleepstudy2$lag_A, na.rm = TRUE)
+sleepstudy2$c_lag_P <- sleepstudy2$lag_P - mean(sleepstudy2$lag_P, na.rm = TRUE)
+```
+
+```{r fit.indisting, eval=if (exists("params")) params$EVAL else FALSE}
+## Dyadic growth-curve model (k = 2)
+fit_dgc <- glmmTMB(Reaction ~ Days +
+                     indisting(0 + member + member:Days | Dyad) +
+                     homcs(0 + member | Dyad:Days),
+                   data = sleepstudy2, dispformula = ~0, REML = TRUE)
+## Stability-and-influence model (k = 3)
+fit_sim <- glmmTMB(Reaction ~ c_lag_A + c_lag_P +
+                     indisting(0 + member + member:c_lag_A +
+                               member:c_lag_P | Dyad) +
+                     homcs(0 + member | Dyad:Days),
+                   data = sleepstudy2, dispformula = ~0, REML = TRUE)
+```
+
+To use the `indisting()` structure, the member identification variable on
+the left-hand side of the bar must be a factor, wherein the two levels
+correspond to the two dyad members. We omit the random intercept with
+`0 +` because the factor expansion of `member` already produces two
+columns, providing intercepts for members 1 and 2. We then include random
+slopes for members 1 and 2 by specifying interactions between the random
+term (e.g., `Days` for the dyadic growth-curve model example) and the
+member factor variable using `:`. Importantly, the terms on the
+left-hand side of the bar must be ordered so that the member factor
+variable by itself appears first (e.g., `member` before `member:Days`);
+this ensures that the correct pattern of equality constraints is imposed.
+The right-hand side of the bar provides the dyad identification variable.
+
+With longitudinal dyadic data, `indisting()` may be combined with
+`dispformula = ~0` and `homcs(0 + member | dyadID:time)` to model
+time-specific similarity in dyad members' residuals.
 
 ## Construction of structured covariance matrices
 


### PR DESCRIPTION
Adds `indisting()`, a covariance structure for indistinguishable dyads (Kenny, Kashy & Cook, 2006). The structure imposes equality constraints on the covariance matrix appropriate when dyad members are exchangeable. Implementation follows the `cs` structure approach, passing the constrained covariance matrix directly to `MVNORM_t`. Includes input validation via `check_indisting_order()` with informative error messages.