### PR TITLE
fix diagnose() scale report and check_zstats documentation

### DIFF
--- a/glmmTMB/R/diagnose.R
+++ b/glmmTMB/R/diagnose.R
@@ -24,7 +24,7 @@
 ##' @param big_zstat numeric tolerance for Z-statistic
 ##' @param check_coefs identify large-magnitude coefficients? (Only checks conditional-model parameters if a (log, logit, cloglog, probit) link is used. Always checks zero-inflation, dispersion, and random-effects parameters. May produce false positives if predictor variables have extremely large scales.)
 ##' @param check_hessian identify non-positive-definite Hessian components?
-##' @param check_zstats identify parameters with unusually large Z-statistics (ratio of standard error to mean)? Identifies likely failures of Wald confidence intervals/p-values.
+##' @param check_zstats identify parameters with unusually large Z-statistics (ratio of estimate to standard error)? Identifies likely failures of Wald confidence intervals/p-values.
 ##' @param check_scales identify predictors with unusually small or large scales?
 ##' @param explain provide detailed explanation of each test?
 ##' @return a logical value based on whether anything questionable was found
@@ -105,7 +105,7 @@ diagnose <- function(fit,
         sdvec <- sdvec[sdvec>0 & abs(log10(sdvec))>big_sd_log10]
         if (length(sdvec)>0) {
             model_OK <- FALSE
-            cat(sprintf("\npredictors with unusually large or small standard deviations (|log10(sd)|>%g):\n\n",sdvec))
+            cat(sprintf("\npredictors with unusually large or small standard deviations (|log10(sd)|>%g):\n\n",big_sd_log10))
             print(sdvec)
             prt_explain("Predictor variables with very narrow or wide ranges generally give rise to parameters with very large or",
                         "small magnitudes, which can sometimes exacerbate numerical instability, and may also be appear",
@@ -173,7 +173,7 @@ diagnose <- function(fit,
             if (any(is.na(h))) {
                 bad <- NA
                 eigs <- eigen(fit$sdr$cov.fixed)
-                complex_eigs <- is.complex(eigs)
+                complex_eigs <- is.complex(eigs$values)
             } else {
                 eigs <- eigen(h)
                 ## non-positive definite means some of the eigenvectors are <= 0

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -21,6 +21,11 @@
       \item \code{profile.glmmTMB} with a custom parallel cluster produced
       error on "object 'new_cl' not found" (GH #1265; Henrik Bengtsson)
       \item Fix mapping for models with rr structures (GH #1276)
+      \item \code{diagnose} now prints the intended threshold value (rather
+      than the flagged standard deviations themselves) in its "unusually
+      large or small standard deviations" report; the \code{check_zstats}
+      argument documentation was corrected to describe the Z-statistic as
+      estimate/std.error (GH #1292; Paul Schmidt)
     }
   } % bug fixes
   %\subsection{USER-VISIBLE CHANGES}{

--- a/glmmTMB/man/diagnose.Rd
+++ b/glmmTMB/man/diagnose.Rd
@@ -33,7 +33,7 @@ diagnose(
 
 \item{check_coefs}{identify large-magnitude coefficients? (Only checks conditional-model parameters if a (log, logit, cloglog, probit) link is used. Always checks zero-inflation, dispersion, and random-effects parameters. May produce false positives if predictor variables have extremely large scales.)}
 
-\item{check_zstats}{identify parameters with unusually large Z-statistics (ratio of standard error to mean)? Identifies likely failures of Wald confidence intervals/p-values.}
+\item{check_zstats}{identify parameters with unusually large Z-statistics (ratio of estimate to standard error)? Identifies likely failures of Wald confidence intervals/p-values.}
 
 \item{check_hessian}{identify non-positive-definite Hessian components?}
 

--- a/glmmTMB/tests/testthat/test-diagnose.R
+++ b/glmmTMB/tests/testthat/test-diagnose.R
@@ -34,3 +34,23 @@ test_that("diagnose with mapped parameters", {
     expect_equal(dd, FALSE)
     expect_true(any(grepl("Unusually large Z-statistics", dd_out)))
 })
+
+test_that("diagnose scale report shows the threshold, not the flagged SDs", {
+    ## the check_scales header should interpolate big_sd_log10 (the threshold),
+    ## not the vector of flagged standard deviations
+    set.seed(101)
+    n <- 300
+    dd <- data.frame(y       = rnorm(n),
+                     x_big   = rnorm(n, sd = 1e4),    # |log10(sd)| ~ 4 > 3
+                     x_small = rnorm(n, sd = 1e-4))   # |log10(sd)| ~ 4 > 3
+    fm <- suppressWarnings(glmmTMB(y ~ x_big + x_small, data = dd))
+    out <- suppressWarnings(capture.output(
+        diagnose(fm, explain = FALSE,
+                 check_coefs = FALSE, check_zstats = FALSE,
+                 check_hessian = FALSE, check_scales = TRUE)))
+    hdr <- grep("standard deviations", out, value = TRUE)
+    ## exactly one header line (the bug recycled it once per flagged predictor) ...
+    expect_length(hdr, 1L)
+    ## ... carrying the threshold big_sd_log10 = 3, not a flagged SD value
+    expect_match(hdr, "|log10(sd)|>3):", fixed = TRUE)
+})


### PR DESCRIPTION
Three small fixes in `diagnose()`, all R-level / documentation (no C++).

### 1. `check_scales` reports the wrong threshold (and repeats the header)

The "unusually large or small standard deviations" header interpolates the
*vector of flagged SDs* into the `%g` slot instead of the threshold
`big_sd_log10`, so the printed threshold is wrong and the header is repeated
once per flagged predictor.

```r
library(glmmTMB)
set.seed(101); n <- 300
dd <- data.frame(y       = rnorm(n),
                 x_big   = rnorm(n, sd = 1e4),
                 x_small = rnorm(n, sd = 1e-4))
fm <- glmmTMB(y ~ x_big + x_small, dd)
diagnose(fm, explain = FALSE,
         check_coefs = FALSE, check_zstats = FALSE, check_hessian = FALSE)

#> before:
#> predictors with unusually large or small standard deviations (|log10(sd)|>9761.51):
#> predictors with unusually large or small standard deviations (|log10(sd)|>9.1882e-05):
#>        x_big      x_small
#> 9.761511e+03 9.188200e-05

#> after:
#> predictors with unusually large or small standard deviations (|log10(sd)|>3):
#>        x_big      x_small
#> 9.761511e+03 9.188200e-05
```

The other checks already interpolate their tolerance (`big_coef`, `big_zstat`);
this aligns `check_scales` with them.

### 2. `check_zstats` documentation has the ratio inverted

`?diagnose` describes the Z-statistic as "(ratio of standard error to mean)".
The function computes `estimate / std.error` (and prints "Large Z-statistics
(estimate/std err) ..."), so the `@param` is corrected to
"(ratio of estimate to standard error)".

### 3. `is.complex()` on the `eigen()` list in the NPD-Hessian branch

In the NA-Hessian fallback, complexity is tested on the `eigen()` *list*
(`is.complex(eigs)`, always `FALSE`) instead of `is.complex(eigs$values)` as the
sibling branch already does. No observable effect today (that fallback
eigendecomposes the real symmetric `cov.fixed`), but it is an obvious
copy-paste slip, fixed for consistency.

### Note, not fixed here

In that same NA-Hessian branch `bad <- NA` has length 1, so the
`length(bad) == 0` "Hessian seems OK" bail-out never triggers and the
subsequent `for (b in bad)` then iterates over `NA`. I left this alone because
the path is hard to reproduce (it needs `NA` entries in the
Richardson-extrapolated Hessian) and the intended behaviour there looks like a
design decision. Happy to follow up with a separate issue/PR if you'd like a
particular fix.

A regression test for (1) is added in `tests/testthat/test-diagnose.R`.

---
*This change was prepared with the assistance of an LLM.*
