### PR TITLE
store/restore pars from estfun() (fixes #1294)

### DIFF
--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -1916,6 +1916,7 @@ estfun.glmmTMB <- function(x, full = FALSE, cluster = getGroups(x), rawnames = F
     original_neg_log_lik <- x$obj$fn(x$fit$par)
     env_vars <- c("par", "last.par", "last.par.best", "last.par.ok",
                   "parameters")
+    env_vars <- intersect(env_vars, ls(x$obj$env)) ## drop nonexistent values
     orig_env_vars <- lapply(env_vars,
                             function(n) x$obj$env[[n]])
     names(orig_env_vars) <- env_vars

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -1914,6 +1914,11 @@ estfun.glmmTMB <- function(x, full = FALSE, cluster = getGroups(x), rawnames = F
     # and gradient.
     original_weights <- x$obj$env$data$weights
     original_neg_log_lik <- x$obj$fn(x$fit$par)
+    env_vars <- c("par", "last.par", "last.par.best", "last.par.ok",
+                  "parameters")
+    orig_env_vars <- lapply(env_vars,
+                            function(n) x$obj$env[[n]])
+    names(orig_env_vars) <- env_vars
 
     # Prepare zero weights vector for below.
     zero_weights <- rep(0, stats::nobs(x))
@@ -1923,7 +1928,11 @@ estfun.glmmTMB <- function(x, full = FALSE, cluster = getGroups(x), rawnames = F
     on.exit({
         # Reset the weights to the original values.
         x$obj$env$data$weights <- original_weights
-        # Retape the TMB object to apply the changes.
+        for (n in env_vars) {
+            assign(n, orig_env_vars[[n]],
+                   envir = x$obj$env)
+        }
+        ## Retape the TMB object to apply the changes.
         x$obj$retape(set.defaults = FALSE)
     })
 

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -30,7 +30,7 @@
       values in the environment of a \code{glmmTMB} object, so that
       (e.g.) subsequent calls to \code{predict} are not modified by
       \code{estfun} (or upstream functions such as \code{vcovHC})
-      (GH#1294, Vincent Arel-Bundock)
+      (GH #1294; Vincent Arel-Bundock)
     }
   } % bug fixes
   %\subsection{USER-VISIBLE CHANGES}{

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -26,6 +26,11 @@
       large or small standard deviations" report; the \code{check_zstats}
       argument documentation was corrected to describe the Z-statistic as
       estimate/std.error (GH #1292; Paul Schmidt)
+      \item the \code{estfun.glmmTMB} correctly restores the parameter
+      values in the environment of a \code{glmmTMB} object, so that
+      (e.g.) subsequent calls to \code{predict} are not modified by
+      \code{estfun} (or upstream functions such as \code{vcovHC})
+      (GH#1294, Vincent Arel-Bundock)
     }
   } % bug fixes
   %\subsection{USER-VISIBLE CHANGES}{

--- a/glmmTMB/tests/testthat/test-methods.R
+++ b/glmmTMB/tests/testthat/test-methods.R
@@ -1111,3 +1111,10 @@ test_that("cl gets passed to confint/profile", {
   ## will fail if cluster was already closed
   expect_no_error(parallel::stopCluster(cl))
 })
+
+test_that("estfun doesn't change internal values inappropriately", {
+    p1 <- head(predict(fm1))
+    e <- estfun(fm1)
+    v <- vcovHC(fm1)
+    expect_identical(head(predict(fm1)), p1)
+})

--- a/glmmTMB/tests/testthat/test-methods.R
+++ b/glmmTMB/tests/testthat/test-methods.R
@@ -1114,7 +1114,7 @@ test_that("cl gets passed to confint/profile", {
 
 test_that("estfun doesn't change internal values inappropriately", {
     p1 <- head(predict(fm1))
-    e <- estfun(fm1)
-    v <- vcovHC(fm1)
+    expect_no_error(estfun(fm1))
+    expect_no_error(vcovHC(fm1))
     expect_identical(head(predict(fm1)), p1)
 })


### PR DESCRIPTION
this correctly stores and restores a variety of `*par*` objects in the TMB object's environment; the set of objects stored is sufficient for the reported problem but the entire content may not be necessary. Conversely, I don't know if there are other downstream operations that would be affected by other modified elements in the environment ...