### PR TITLE
replace deprecated .-type names in structure(), in tests

### DIFF
--- a/glmmTMB/tests/testthat/test-VarCorr.R
+++ b/glmmTMB/tests/testthat/test-VarCorr.R
@@ -149,7 +149,7 @@ getVCText <- function(obj,...) {
 expect_equal(getVCText(vc),
              structure(list(V3 = c(2.19412, 0.21493, 1.31004),
                             V4 = c(NA, -0.581, NA)),
-                       .Names = c("V3", "V4"),
+                       names = c("V3", "V4"),
                        class = "data.frame", row.names = c(NA, -3L)),
              tolerance=2e-5)
 
@@ -164,7 +164,7 @@ c2 <- getVCText(vc,comp=c("Variance","Std.Dev."),digits=2)
 ##                " Residual             1.716    1.31          "))
 expect_equal(c2,
              structure(list(V3 = c(4.814, 0.046, 1.716), V4 = c(2.19, 0.21,
-1.31)), .Names = c("V3", "V4"), class = "data.frame", row.names = c(NA,
+1.31)), names = c("V3", "V4"), class = "data.frame", row.names = c(NA,
 -3L)))
 ## variance only
 c3 <- getVCText(vc,comp=c("Variance"))
@@ -176,7 +176,7 @@ c3 <- getVCText(vc,comp=c("Variance"))
 ##               "          age         0.046192 -0.581",
 ##               " Residual             1.716203       "))
 expect_equal(c3,structure(list(V3 = c(4.814071, 0.046192, 1.716208), V4 = c(NA,
--0.581, NA)), .Names = c("V3", "V4"), class = "data.frame", row.names = c(NA,
+-0.581, NA)), names = c("V3", "V4"), class = "data.frame", row.names = c(NA,
 -3L)),
 tolerance=5e-5)
 

--- a/glmmTMB/tests/testthat/test-families.R
+++ b/glmmTMB/tests/testthat/test-families.R
@@ -110,7 +110,7 @@ test_that("beta", {
                   data=dd)
     expect_equal(fixef(m1)[[1]],
                  structure(c(1.98250567574413, 0.843382531038295),
-                           .Names = c("(Intercept)", "x")),
+                           names = c("(Intercept)", "x")),
                  tol=1e-5)
     expect_equal(c(VarCorr(m1)[[1]][[1]]),
                  0.433230926800709, tol=1e-5)
@@ -132,7 +132,7 @@ test_that("nbinom", {
                   data=dd)
     expect_equal(fixef(m1)[[1]],
                  structure(c(2.09866748794435, 1.12703589660625),
-                           .Names = c("(Intercept)", "x")),
+                           names = c("(Intercept)", "x")),
                  tolerance = 1e-5)
     expect_equal(c(VarCorr(m1)[[1]][[1]]),
                   9.54680210862774, tolerance = 1e-5)
@@ -171,9 +171,9 @@ test_that("nbinom", {
     ## coef(mod1 <- MASS::glm.nb(obs~x,link="identity",dat))
     expect_equal(fixef(glmmTMB(obs~x, family=nbinom2(link="identity"), dat)),
        structure(list(cond = structure(c(115.092240041138, 1.74390840106971),
-       .Names = c("(Intercept)", "x")), zi = numeric(0),
-       disp = structure(1.71242627201796, .Names = "(Intercept)")),
-       .Names = c("cond", "zi", "disp"), class = "fixef.glmmTMB"))
+       names = c("(Intercept)", "x")), zi = numeric(0),
+       disp = structure(1.71242627201796, names = "(Intercept)")),
+       names = c("cond", "zi", "disp"), class = "fixef.glmmTMB"))
 
 
     ## segfault (GH #248)

--- a/glmmTMB/tests/testthat/test-methods.R
+++ b/glmmTMB/tests/testthat/test-methods.R
@@ -169,7 +169,7 @@ test_that("terms", {
     ## if predvars is not properly attached to term, this will
     ## fail as it tries to construct a 3-knot spline from a single point
     expect_equal(model.matrix(delete.response(terms(m)),data=data.frame(x=1)),
-      structure(c(1, 0, 0, 0), .Dim = c(1L, 4L), .Dimnames = list("1",
+      structure(c(1, 0, 0, 0), dim = c(1L, 4L), dimnames = list("1",
     c("(Intercept)", "ns(x, 3)1", "ns(x, 3)2", "ns(x, 3)3")),
     assign = c(0L, 1L, 1L, 1L)))
 })
@@ -210,8 +210,8 @@ test_that("confint", {
     expect_equal(ci,
         structure(c(238.406083254105, 7.52295734348693,
                     264.404107485727, 13.4116167530013),
-                  .Dim = c(2L, 2L),
-                  .Dimnames = list(c("(Intercept)", "Days"),
+                  dim = c(2L, 2L),
+                  dimnames = list(c("(Intercept)", "Days"),
                                    c("2.5 %", "97.5 %"))),
         ## answers changed with var -> SD shift, increased tolerance
         ##  rather than substituting new values
@@ -246,22 +246,22 @@ structure(c(5.48098713179567, 0.0248163864044954, 183.810584890723,
     expect_equal(ci.prof0,
                  structure(c(238.216039176535, 7.99674863649355, 3.758897,
                              264.368471102549, 12.8955469713508, 3.966739),
-                           .Dim = 3:2, .Dimnames = list(c("(Intercept)", "Days", "disp~(Intercept)"),
+                           dim = 3:2, dimnames = list(c("(Intercept)", "Days", "disp~(Intercept)"),
                                                         c("2.5 %", "97.5 %"))),
                  tolerance=1e-4)
 
     ci.prof <- confint(fm2,parm=1,method="profile", npts=3)
     expect_equal(ci.prof,
                  structure(c(237.27249, 265.13383),
-                           .Dim = 1:2, .Dimnames = list(
+                           dim = 1:2, dimnames = list(
                                 "(Intercept)", c("2.5 %", "97.5 %"))),
                  tolerance=1e-6)
     ## uniroot CI
     ci.uni <- confint(fm2,parm=1,method="uniroot")
     expect_equal(ci.uni,
                  structure(c(237.68071,265.12949,251.4050979),
-                        .Dim = c(1L, 3L),
-                        .Dimnames = list("(Intercept)", c("2.5 %", "97.5 %", "Estimate"))),
+                        dim = c(1L, 3L),
+                        dimnames = list("(Intercept)", c("2.5 %", "97.5 %", "Estimate"))),
                  ## values changed slightly with var -> SD param shift for Gaussian; loosened tolerance
                  tolerance=1e-3)
     ## check against 'raw' tmbroot
@@ -399,7 +399,7 @@ test_that("vcov", {
            structure(c("(Intercept)", "Days", "disp~(Intercept)",
                        "theta_Days|Subject.1", "theta_Days|Subject.2",
                        "theta_Days|Subject.3"),
-          .Names = c("cond1", "cond2", "disp", "theta1", "theta2", "theta3")))
+          names = c("cond1", "cond2", "disp", "theta1", "theta2", "theta3")))
     ## vcov doesn't include dispersion for non-dispersion families ...
     expect_equal(dim(vcov(fm2P,full=TRUE)),c(5,5))
     ## oops, dot_check() disabled in vcov.glmmTMB ...

--- a/glmmTMB/tests/testthat/test-zi.R
+++ b/glmmTMB/tests/testthat/test-zi.R
@@ -22,13 +22,13 @@ test_that("zi", {
     expect_equal(fixef(owls_nb2),
   structure(list(cond = structure(c(0.812028613585629, -0.342496105044418,
       -0.0751681324132088, 0.122484981295054),
-      .Names = c("(Intercept)", "FoodTreatmentSatiated", "SexParentMale",
+      names = c("(Intercept)", "FoodTreatmentSatiated", "SexParentMale",
                  "FoodTreatmentSatiated:SexParentMale")),
       zi = structure(c(-2.20863281353936, 1.86779027553285, -0.825200772653965,
-    0.451435813933449), .Names = c("(Intercept)", "FoodTreatmentSatiated",
+    0.451435813933449), names = c("(Intercept)", "FoodTreatmentSatiated",
      "SexParentMale", "FoodTreatmentSatiated:SexParentMale")),
-    disp = structure(1.33089630005212, .Names = "(Intercept)")),
-    .Names = c("cond", "zi", "disp"), class = "fixef.glmmTMB"),
+    disp = structure(1.33089630005212, names = "(Intercept)")),
+    names = c("cond", "zi", "disp"), class = "fixef.glmmTMB"),
   tolerance=1e-5)
     expect_equal(fixef(owls_nb2),fixef(owls_nb3))
 })


### PR DESCRIPTION
This resolves a NOTE that's now popped up in CRAN tests