### PR TITLE
vcov() fails for REML fits with no free fixed effects

### DIFF
--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -420,7 +420,12 @@ vcov.glmmTMB <- function(object, full = FALSE, include_nonest = TRUE,
     warning("Calculating sdreport. Use se=TRUE in glmmTMB to avoid repetitive calculation of sdreport")
     sdr <- sdreport(object$obj, getJointPrecision=REML)
   }
-  if (REML) {
+  ## a REML fit with no free fixed effects to integrate out (e.g. y ~ 0, or
+  ## any model whose whole 'beta' vector is map-fixed) leaves sdreport()
+  ## without a joint precision matrix; such a fit is numerically identical
+  ## to the ML fit, so fall through to the ordinary path rather than
+  ## setting dimnames on a NULL Q
+  if (REML && !is.null(sdr$jointPrecision)) {
       if (sandwich) {
         stop("sandwich estimator is not available for REML fits")
       }

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -425,10 +425,10 @@ vcov.glmmTMB <- function(object, full = FALSE, include_nonest = TRUE,
   ## without a joint precision matrix; such a fit is numerically identical
   ## to the ML fit, so fall through to the ordinary path rather than
   ## setting dimnames on a NULL Q
+  if (REML && sandwich) {
+    stop("sandwich estimator is not available for REML fits")
+  }
   if (REML && !is.null(sdr$jointPrecision)) {
-      if (sandwich) {
-        stop("sandwich estimator is not available for REML fits")
-      }
       ## NOTE: This code would also work in non-REML case provided
       ## that jointPrecision is present in the object.
       Q <- sdr$jointPrecision

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -29,6 +29,12 @@
   } % new features
  \subsection{BUG FIXES}{
     \itemize{
+      \item \code{vcov} (and hence \code{summary}, \code{confint},
+      \code{car::Anova}) no longer fails with "attempt to set an attribute
+      on NULL" for a \code{REML=TRUE} fit that has no free fixed effects to
+      integrate out (e.g. \code{y ~ 0}, or a model whose entire \code{beta}
+      vector is fixed via \code{map}); such fits are numerically identical
+      to the corresponding ML fit
       \item \code{profile.glmmTMB} with a custom parallel cluster produced
       error on "object 'new_cl' not found" (GH #1265; Henrik Bengtsson)
       \item Fix mapping for models with rr structures (GH #1276)

--- a/glmmTMB/tests/testthat/test-reml.R
+++ b/glmmTMB/tests/testthat/test-reml.R
@@ -42,6 +42,28 @@ test_that("REML with all parameters fixed", {
     expect_equal(vcov(mod6_REML), vcov(mod6_ML))
 })
 
+test_that("REML with no free fixed effects stays usable", {
+    ## with nothing random left at all -- no random effects, and no free
+    ## fixed effects to integrate out -- sdreport() returns no
+    ## jointPrecision, and vcov() used to fail with "attempt to set an
+    ## attribute on NULL"
+    set.seed(101)
+    dd <- data.frame(y = rnorm(50), x = rnorm(50))
+    m0 <- glmmTMB(y ~ 0, data = dd, REML = TRUE)
+    expect_null(m0$sdr$jointPrecision)
+    expect_s3_class(vcov(m0), "vcov.glmmTMB")
+    expect_s3_class(summary(m0), "summary.glmmTMB")
+    ## same when every fixed effect is map-fixed
+    m1 <- glmmTMB(y ~ x, data = dd, REML = TRUE,
+                  start = list(beta = c(0, 0)),
+                  map = list(beta = factor(c(NA, NA))))
+    expect_null(m1$sdr$jointPrecision)
+    expect_s3_class(vcov(m1), "vcov.glmmTMB")
+    ## a genuine REML fit is unaffected: beta really is integrated out
+    expect_setequal(unique(names(fm1.glmmTMB$sdr$par.random)),
+                    c("beta", "b"))
+})
+
 test_that("correct df.residual for REML=TRUE", {
     ## nobs = 180 - 6 (beta = 2 + betadisp = 1 + theta = 3)
     expect_equal(df.residual(fm1.glmmTMB), 174)


### PR DESCRIPTION
A `REML=TRUE` fit with nothing left to integrate out returns an object whose `vcov()` errors:

```r
d <- data.frame(y = rnorm(50))
m <- glmmTMB(y ~ 0, data = d, REML = TRUE)
vcov(m)
## Error in dimnames(Q) <- list(...) : attempt to set an attribute on NULL
```

`summary()`, `confint()` and `car::Anova()` go the same way, since they all route through `vcov()`.

The trigger is a model with no random effects *and* no free fixed effects: `randomArg` gets `"beta"` with zero free elements, so nothing is random, `sdreport()` returns no `jointPrecision`, and the REML branch of `vcov.glmmTMB` does `dimnames(Q) <- ...` on a `NULL`. It also happens when the whole `beta` vector is fixed via `map`.

Such a fit is numerically the ML fit (identical objective and parameter vector), so the fix is to take the ordinary covariance path when there is no joint precision matrix rather than special-casing it.

Tests cover both routes into the state (`y ~ 0` and a fully `map`-fixed `beta`), and assert that a genuine REML fit is unaffected, i.e. still has `beta` in `par.random`. Full suite passes.

I hit this via the ordinal family in #1298, where it is reachable from an ordinary null model because that family always map-fixes its intercept. Splitting it out since it is general and stands alone; #1298 carries a copy that will drop out once this merges.
