### PR TITLE
return proper weights from binomial models with two-column-matrix responses

### DIFF
--- a/glmmTMB/NAMESPACE
+++ b/glmmTMB/NAMESPACE
@@ -18,6 +18,7 @@ S3method(formula,glmmTMB)
 S3method(getGroups,glmmTMB)
 S3method(getME,glmmTMB)
 S3method(has.intercept,glmmTMB)
+S3method(isGLMM,glmmTMB)
 S3method(isLMM,glmmTMB)
 S3method(logLik,glmmTMB)
 S3method(meatHC,default)
@@ -81,6 +82,7 @@ export(get_cor)
 export(glmmTMB)
 export(glmmTMBControl)
 export(gt_load)
+export(isGLMM)
 export(lognormal)
 export(meatHC)
 export(nbinom1)
@@ -117,129 +119,154 @@ if(getRversion() >= "3.6.0") { S3method(car::Anova, glmmTMB) } else { export(Ano
 if(getRversion() >= "3.6.0") { S3method(effects::Effect, glmmTMB)  } else { export(Effect.glmmTMB) }
 if(getRversion() >= "3.6.0") { S3method(multcomp::modelparm, glmmTMB) } else {  export(modelparm.glmmTMB) }
 if(getRversion()>='3.3.0') { importFrom(stats, sigma) } else { importFrom(lme4,sigma) }
-importFrom(Matrix,Cholesky)
-importFrom(Matrix,crossprod)
-importFrom(Matrix,diag)
-importFrom(Matrix,qr)
-importFrom(Matrix,qr2rankMatrix)
-importFrom(Matrix,rankMatrix)
-importFrom(Matrix,solve)
-importFrom(Matrix,t)
-importFrom(TMB,MakeADFun)
-importFrom(TMB,sdreport)
-importFrom(TMB,tmbprofile)
-importFrom(lme4,.prt.VC)
-importFrom(lme4,.prt.aictab)
-importFrom(lme4,.prt.call)
-importFrom(lme4,.prt.family)
-importFrom(lme4,.prt.grps)
-importFrom(lme4,.prt.resids)
-importFrom(lme4,getME)
-importFrom(lme4,isLMM)
-importFrom(lme4,refit)
-importFrom(methods,as)
-importFrom(methods,is)
-importFrom(methods,new)
-importFrom(mgcv,PredictMat)
-importFrom(mgcv,s)
-importFrom(mgcv,smooth2random)
-importFrom(mgcv,smoothCon)
-importFrom(nlme,VarCorr)
-importFrom(nlme,fixef)
-importFrom(nlme,getGroups)
-importFrom(nlme,ranef)
-importFrom(numDeriv,hessian)
-importFrom(numDeriv,jacobian)
-importFrom(reformulas,"RHSForm<-")
-importFrom(reformulas,RHSForm)
-importFrom(reformulas,addForm)
-importFrom(reformulas,addForm0)
-importFrom(reformulas,anySpecial)
-importFrom(reformulas,extractForm)
-importFrom(reformulas,findbars)
-importFrom(reformulas,findbars_x)
-importFrom(reformulas,formatVC)
-importFrom(reformulas,inForm)
-importFrom(reformulas,makeOp)
-importFrom(reformulas,mkReTrms)
-importFrom(reformulas,noSpecials)
-importFrom(reformulas,no_specials)
-importFrom(reformulas,nobars)
-importFrom(reformulas,reOnly)
-importFrom(reformulas,splitForm)
-importFrom(reformulas,sub_specials)
-importFrom(reformulas,subbars)
-importFrom(sandwich,bread)
-importFrom(sandwich,estfun)
-importFrom(sandwich,vcovHC)
-importFrom(splines,backSpline)
-importFrom(splines,interpSpline)
-importFrom(stats,"contrasts<-")
-importFrom(stats,.getXlevels)
-importFrom(stats,AIC)
-importFrom(stats,BIC)
-importFrom(stats,anova)
-importFrom(stats,approx)
-importFrom(stats,as.formula)
-importFrom(stats,binomial)
-importFrom(stats,complete.cases)
-importFrom(stats,confint)
-importFrom(stats,contrasts)
-importFrom(stats,cov2cor)
-importFrom(stats,delete.response)
-importFrom(stats,df.residual)
-importFrom(stats,dist)
-importFrom(stats,dnbinom)
-importFrom(stats,dpois)
-importFrom(stats,family)
-importFrom(stats,fitted)
-importFrom(stats,formula)
-importFrom(stats,gaussian)
-importFrom(stats,getCall)
-importFrom(stats,logLik)
-importFrom(stats,make.link)
-importFrom(stats,model.frame)
-importFrom(stats,model.matrix)
-importFrom(stats,model.response)
-importFrom(stats,model.weights)
-importFrom(stats,na.fail)
-importFrom(stats,na.omit)
-importFrom(stats,na.pass)
-importFrom(stats,napredict)
-importFrom(stats,nlminb)
-importFrom(stats,nobs)
-importFrom(stats,optimHess)
-importFrom(stats,pbinom)
-importFrom(stats,pchisq)
-importFrom(stats,plogis)
-importFrom(stats,pnbinom)
-importFrom(stats,pnorm)
-importFrom(stats,poisson)
-importFrom(stats,ppois)
-importFrom(stats,predict)
-importFrom(stats,printCoefmat)
-importFrom(stats,profile)
-importFrom(stats,pt)
-importFrom(stats,qchisq)
-importFrom(stats,qlogis)
-importFrom(stats,qnbinom)
-importFrom(stats,qnorm)
-importFrom(stats,reformulate)
-importFrom(stats,residuals)
-importFrom(stats,rnbinom)
-importFrom(stats,rnorm)
-importFrom(stats,runif)
-importFrom(stats,sd)
-importFrom(stats,setNames)
-importFrom(stats,simulate)
-importFrom(stats,terms)
-importFrom(stats,update)
-importFrom(stats,var)
-importFrom(stats,vcov)
-importFrom(stats,weights)
-importFrom(stats,xtabs)
-importFrom(utils,capture.output)
-importFrom(utils,combn)
-importFrom(utils,head)
-importFrom(utils,packageVersion)
+importFrom(Matrix,
+  Cholesky,
+  crossprod,
+  diag,
+  qr,
+  qr2rankMatrix,
+  rankMatrix,
+  solve,
+  t
+)
+importFrom(TMB,
+  MakeADFun,
+  sdreport,
+  tmbprofile
+)
+importFrom(lme4,
+  .prt.VC,
+  .prt.aictab,
+  .prt.call,
+  .prt.family,
+  .prt.grps,
+  .prt.resids,
+  getME,
+  isGLMM,
+  isLMM,
+  refit
+)
+importFrom(methods,
+  as,
+  is,
+  new
+)
+importFrom(mgcv,
+  PredictMat,
+  s,
+  smooth2random,
+  smoothCon
+)
+importFrom(nlme,
+  VarCorr,
+  fixef,
+  getGroups,
+  ranef
+)
+importFrom(numDeriv,
+  hessian,
+  jacobian
+)
+importFrom(reformulas,
+  "RHSForm<-",
+  RHSForm,
+  addForm,
+  addForm0,
+  anySpecial,
+  extractForm,
+  findbars,
+  findbars_x,
+  formatVC,
+  inForm,
+  makeOp,
+  mkReTrms,
+  noSpecials,
+  no_specials,
+  nobars,
+  reOnly,
+  splitForm,
+  sub_specials,
+  subbars
+)
+importFrom(sandwich,
+  bread,
+  estfun,
+  vcovHC
+)
+importFrom(splines,
+  backSpline,
+  interpSpline
+)
+importFrom(stats,
+  "contrasts<-",
+  .getXlevels,
+  AIC,
+  BIC,
+  anova,
+  approx,
+  as.formula,
+  binomial,
+  complete.cases,
+  confint,
+  contrasts,
+  cov2cor,
+  delete.response,
+  df.residual,
+  dist,
+  dnbinom,
+  dpois,
+  family,
+  fitted,
+  formula,
+  gaussian,
+  getCall,
+  logLik,
+  make.link,
+  model.frame,
+  model.matrix,
+  model.response,
+  model.weights,
+  na.fail,
+  na.omit,
+  na.pass,
+  napredict,
+  nlminb,
+  nobs,
+  optimHess,
+  pbinom,
+  pchisq,
+  plogis,
+  pnbinom,
+  pnorm,
+  poisson,
+  ppois,
+  predict,
+  printCoefmat,
+  profile,
+  pt,
+  qchisq,
+  qlogis,
+  qnbinom,
+  qnorm,
+  reformulate,
+  residuals,
+  rnbinom,
+  rnorm,
+  runif,
+  sd,
+  setNames,
+  simulate,
+  terms,
+  update,
+  var,
+  vcov,
+  weights,
+  xtabs
+)
+importFrom(utils,
+  capture.output,
+  combn,
+  head,
+  packageVersion
+)
 useDynLib(glmmTMB)

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -1809,18 +1809,15 @@ coef.glmmTMB <- function(object,
 ##' Extract weights from a glmmTMB object
 ##'
 ##' @details
-##' At present only explicitly specified
-##' \emph{prior weights} (i.e., weights specified
-##' in the \code{weights} argument) can be extracted from a fitted model.
-##' \itemize{
-##' \item Unlike other GLM-type models such as \code{\link{glm}} or
-##' \code{\link[lme4]{glmer}}, \code{weights()} does not currently return
-##' the total number of trials when binomial responses are specified
-##' as a two-column matrix.
-##' \item Since \code{glmmTMB} does not fit models via iteratively
+##' Returns the \emph{prior weights} used in fitting, i.e. weights
+##' specified in the \code{weights} argument. For binomial-type families
+##' fit with a two-column matrix response (\code{cbind(successes, failures)}),
+##' the total number of trials is included as well (multiplied by the
+##' \code{weights} argument, if specified), matching the behaviour of
+##' \code{\link{glm}} and \code{\link[lme4]{glmer}}.
+##' Since \code{glmmTMB} does not fit models via iteratively
 ##' weighted least squares, \code{working weights} (see \code{\link[stats:glm]{weights.glm}}) are unavailable.
-##' }
-##' @importFrom stats model.frame
+##' @importFrom stats model.frame model.response
 ##' @importFrom stats weights
 ##' @param object a fitted \code{glmmTMB} object
 ##' @param type weights type
@@ -1832,7 +1829,16 @@ weights.glmmTMB <- function(object, type="prior", ...) {
         warning("unused arguments ignored: ",
              paste(shQuote(names(list(...))),collapse=","))
     }
-    stats::model.frame(object)[["(weights)"]]
+    fr <- stats::model.frame(object)
+    w <- fr[["(weights)"]]
+    mr <- model.response(fr)
+    if (!is.null(dim(mr))) {
+        ## binomial-type response given as cbind(successes, failures):
+        ## total trials are an implicit weight, as in glm/glmer
+        n <- unname(mr[, 1] + mr[, 2])
+        w <- if (is.null(w)) n else w * n
+    }
+    w
 }
 
 # would like to export this only as a method, but not sure how ...

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -1750,9 +1750,7 @@ refit.glmmTMB <- function(object, newresp, ...) {
 ## ------  should work with fixef() + ranef()  alone
 coefMer <- function(object, component=NULL, ...)
 {
-    if (length(list(...)))
-        warning('arguments named "', paste(names(list(...)), collapse = ", "),
-                '" ignored')
+    check_dots(..., .action = "warning")
     fef <- fixef(object)
     if (!is.null(component)) fef <- fef[[component]]
     fef <- data.frame(rbind(fef), check.names = FALSE)
@@ -1825,10 +1823,8 @@ coef.glmmTMB <- function(object,
 ##' @export
 weights.glmmTMB <- function(object, type="prior", ...) {
     type <- match.arg(type)  ## other types are *not* OK
-    if (length(list(...)>0)) {
-        warning("unused arguments ignored: ",
-             paste(shQuote(names(list(...))),collapse=","))
-    }
+  
+    check_dots(..., .action = "warning")
     fr <- stats::model.frame(object)
     w <- fr[["(weights)"]]
     mr <- model.response(fr)

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -2262,3 +2262,14 @@ vcovHC.glmmTMB <- function(x, type = "HC0", sandwich = TRUE, ...) {
         meatHC(x, ...)
     }
 }
+
+#' @importFrom lme4 isGLMM
+#' @export
+lme4::isGLMM
+
+#' @export
+isGLMM.glmmTMB <- function(x,...) {
+  check_dots(...)
+  f <- family(x)
+  !(f$family == "gaussian" && f$link == "identity")
+}

--- a/glmmTMB/R/utils.R
+++ b/glmmTMB/R/utils.R
@@ -188,9 +188,13 @@ check_dots <- function(..., .ignore = NULL, .action="stop") {
         L <- L[!names(L) %in% .ignore]
     }
     if (length(L)>0) {
+        args <- paste(shQuote(names(L)), collapse=",")
+        msg <- switch(.action,
+                      stop = sprintf("unknown arguments: %s", args),
+                      warning = ,
+                      message = sprintf("unknown arguments ignored: %s", args))
         FUN <- get(.action)
-        FUN("unknown arguments: ",
-            paste(names(L), collapse=","))
+        FUN(msg)
     }
     return(NULL)
 }

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -68,6 +68,10 @@
       dimension mismatch in \code{emmeans}, and a singular-matrix error or
       \code{NA} test statistic in \code{Anova}); such coefficients are
       treated as known constants with zero variance
+      \item \code{weights()} now returns the total number of trials for
+      binomial-type models fitted with a two-column matrix
+      (\code{cbind(successes, failures)}) response, matching \code{glm} and
+      \code{glmer} (GH #1319)
     }
   } % bug fixes
   %\subsection{USER-VISIBLE CHANGES}{

--- a/glmmTMB/man/reexports.Rd
+++ b/glmmTMB/man/reexports.Rd
@@ -4,6 +4,7 @@
 \name{reexports}
 \alias{reexports}
 \alias{refit}
+\alias{isGLMM}
 \title{Objects exported from other packages}
 \keyword{internal}
 \description{
@@ -11,6 +12,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{lme4}{\code{\link[lme4]{refit}}}
+  \item{lme4}{\code{\link[lme4:isGLMM]{isGLMM()}}, \code{\link[lme4:refit]{refit()}}}
 }}
 

--- a/glmmTMB/man/weights.glmmTMB.Rd
+++ b/glmmTMB/man/weights.glmmTMB.Rd
@@ -17,15 +17,12 @@
 Extract weights from a glmmTMB object
 }
 \details{
-At present only explicitly specified
-\emph{prior weights} (i.e., weights specified
-in the \code{weights} argument) can be extracted from a fitted model.
-\itemize{
-\item Unlike other GLM-type models such as \code{\link{glm}} or
-\code{\link[lme4]{glmer}}, \code{weights()} does not currently return
-the total number of trials when binomial responses are specified
-as a two-column matrix.
-\item Since \code{glmmTMB} does not fit models via iteratively
+Returns the \emph{prior weights} used in fitting, i.e. weights
+specified in the \code{weights} argument. For binomial-type families
+fit with a two-column matrix response (\code{cbind(successes, failures)}),
+the total number of trials is included as well (multiplied by the
+\code{weights} argument, if specified), matching the behaviour of
+\code{\link{glm}} and \code{\link[lme4]{glmer}}.
+Since \code{glmmTMB} does not fit models via iteratively
 weighted least squares, \code{working weights} (see \code{\link[stats:glm]{weights.glm}}) are unavailable.
-}
 }

--- a/glmmTMB/tests/testthat/test-methods.R
+++ b/glmmTMB/tests/testthat/test-methods.R
@@ -1195,3 +1195,10 @@ test_that("estfun doesn't change internal values inappropriately", {
     expect_no_error(vcovHC(fm1))
     expect_identical(head(predict(fm1)), p1)
 })
+
+test_that("isGLMM", {
+  expect_true(isGLMM(gm1))
+  expect_false(isGLMM(fm1))
+  fm0 <- update(fm_noRE, family = gaussian(link = "log"))
+  expect_true(isGLMM(fm0))
+})

--- a/glmmTMB/tests/testthat/test-utils.R
+++ b/glmmTMB/tests/testthat/test-utils.R
@@ -74,3 +74,13 @@ test_that("up2date doesn't mangle parameter order", {
                      c(-0.52792570545058, 0.2441352439504439))
 })
 
+test_that("check_dots", {
+    expect_null(check_dots())
+    expect_null(check_dots(foo = 1, .ignore = "foo"))
+    expect_error(check_dots(foo = 1, bar = 2), "'foo','bar'")
+    expect_warning(check_dots(foo = 1, .action = "warning"),
+                   "unknown arguments ignored: 'foo'")
+    expect_message(check_dots(foo = 1, .action = "message"),
+                    "unknown arguments ignored: 'foo'")
+})
+

--- a/glmmTMB/tests/testthat/test-weight.R
+++ b/glmmTMB/tests/testthat/test-weight.R
@@ -55,3 +55,16 @@ test_that("Estimates are the same", {
 	expect_equal(ranef(wei_glmmtmb), ranef(ind_glmmtmb), tolerance=2e-5)
 	expect_equal(AIC(wei_glmmtmb), AIC(ind_glmmtmb), tolerance=1e-5)
 })
+
+test_that("weights() returns total trials for cbind() binomial response (GH #1319)", {
+    cbpp <- lme4::cbpp
+    form <- cbind(incidence, size - incidence) ~ period + (1|herd)
+    m <- glmmTMB(form, data = cbpp, family = binomial)
+    ## matches weights(lme4::glmer(form, data = cbpp, family = binomial))
+    expect_equal(weights(m), cbpp$size)
+
+    ## proportion response + explicit weights should be unaffected
+    form2 <- incidence/size ~ period + (1|herd)
+    mP <- glmmTMB(form2, data = cbpp, family = binomial, weights = size)
+    expect_equal(weights(mP), cbpp$size)
+})

--- a/glmmTMB/tests/testthat/test-weight.R
+++ b/glmmTMB/tests/testthat/test-weight.R
@@ -45,7 +45,7 @@ test_that("Return weights", {
   expect_equal(weights(wei_glmmtmb, type="prior"), aggdat$Freq)
   expect_error(weights(wei_glmmtmb, type = "working"), "should be")
   expect_warning(weights(wei_glmmtmb, junk = "abc"),
-                 "unused arguments ignored")
+                 "unknown arguments ignored")
 })
 
 ind_glmmtmb <<- glmmTMB(y ~ x+(x|i), data=inddat, family="poisson")


### PR DESCRIPTION
`weights.glmmTMB()` only returned the value of the explicit `weights` argument, so it gave NULL for `cbind(successes, failures) ~ ...` fits even though the trial totals were computed internally as `size`. Now derives the trial total from the two-column response and folds it in as glm/glmer do, fixing GH #1319.

oops: accidentally also included an implementation of `isGLMM` in this PR ...