### PR TITLE
Report ordinal thresholds with delta-method SEs in summary() (#1323)

### DIFF
--- a/glmmTMB/R/glmmTMB.R
+++ b/glmmTMB/R/glmmTMB.R
@@ -2263,6 +2263,12 @@ ngrps.factor <- function(object, ...) nlevels(object)
 ##' warning, because their performance (and theoretical justification) for GLMMs is poorly understood
 ##' @param ... unused, for method compatibility
 ##' @inheritParams vcov.glmmTMB
+##' @details For the \code{ordinal} family, the returned object has a
+##' \code{thresholds} element (a matrix of threshold estimates, delta-method
+##' standard errors, and z values), printed as \dQuote{Threshold coefficients};
+##' the thresholds are estimated internally via a softmax parameterization, so
+##' the corresponding rows of \code{vcov(., full = TRUE)} are not on the
+##' threshold scale
 ##' @export
 summary.glmmTMB <- function(object, sandwich = FALSE, ddf=c("asymptotic", "kenward-roger", "satterthwaite"), cluster = getGroups(object), ...) {
     check_dots(...)
@@ -2331,6 +2337,17 @@ summary.glmmTMB <- function(object, sandwich = FALSE, ddf=c("asymptotic", "kenwa
         }
     }
 
+    ## ordinal family: thresholds with delta-method SEs (GH #1323). Kept
+    ## separate from 'coefficients' so downstream code iterating over
+    ## cond/zi/disp tables is unaffected. Sandwich vcov is not used here
+    thresholds <- NULL
+    if (famL$family == "ordinal") {
+        thresholds <- ordinal_thresholds(object)
+        thresholds <- cbind(thresholds,
+                            "z value" = thresholds[, "Estimate"] /
+                                thresholds[, "Std. Error"])
+    }
+
     llAIC <- llikAIC(object)
 
     ## FIXME: You can't count on object@re@flist,
@@ -2342,6 +2359,7 @@ summary.glmmTMB <- function(object, sandwich = FALSE, ddf=c("asymptotic", "kenwa
 		   ngrps = ngrps(object),
                    nobs = nobs(object),
 		   coefficients = coefs,
+                   thresholds = thresholds,
                    sigma = sig,
 		   vcov = vv, # No need to potentially recompute here anything.
 		   varcor = varcor, # and use formatVC(.) for printing.
@@ -2395,6 +2413,11 @@ print.summary.glmmTMB <- function(x, digits = max(3, getOption("digits") - 3),
             printCoefmat(cc, zap.ind = 3, #, tst.ind = 4
                          digits = digits, signif.stars = signif.stars)
         } ## if (p>0)
+    }
+    if (!is.null(x$thresholds)) {
+        cat("\nThreshold coefficients:\n")
+        printCoefmat(x$thresholds, digits = digits, has.Pvalue = FALSE,
+                     signif.stars = FALSE)
     }
     if (!is.null(x$priors)) {
         cat("\nPriors:\n")

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -772,7 +772,11 @@ ordinal_thresholds <- function(object) {
 #' @importFrom stats plogis qlogis
 printFamily <- function(object) {
     val <- family_params(object)
-    if (length(val) > 0) {
+    if (object$modelInfo$family$family == "ordinal") {
+        cat("\nThreshold coefficients:",
+            paste(names(val), formatC(val, digits = 3), sep = " = ",
+                  collapse = ", "), "\n")
+    } else if (length(val) > 0) {
         cat(sprintf("\n%s estimate: %s",
                     names(val)[1],
                     paste(formatC(val, digits=3),

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -738,6 +738,29 @@ family_params <- function(object) {
            )
 }
 
+## ordinal family: thresholds and their delta-method standard errors.
+## The thresholds are a joint function of *all* psi elements,
+## theta_j = qlogis(cumsum(softmax(c(psi, 0)))_j), so univariate
+## transformation of the psi-scale variances does not apply; use the
+## analytic Jacobian
+## J[j, m] = s[m] * ((m <= j) - C_j) / (C_j * (1 - C_j)),
+## where s = softmax(c(psi, 0)) and C_j = cumsum(s)[j]
+ordinal_thresholds <- function(object) {
+    fp <- family_params(object)
+    pars <- get_pars(object)
+    tf <- unname(pars[names(pars) == "psi"])
+    w <- exp(c(tf, 0) - max(tf, 0))
+    s <- w / sum(w)
+    Cj <- cumsum(s)[seq_along(tf)]
+    J <- outer(seq_along(tf), seq_along(tf),
+               function(j, m) s[m] * ((m <= j) - Cj[j]) /
+                              (Cj[j] * (1 - Cj[j])))
+    Vfull <- vcov(object, full = TRUE)
+    vi <- match(names(fp), rownames(Vfull))
+    se <- sqrt(diag(J %*% Vfull[vi, vi] %*% t(J)))
+    cbind("Estimate" = fp, "Std. Error" = se)
+}
+
 ## obsolete
 .tweedie_power <- function(object) {
     warning(".tweedie_power is deprecated in favor of family_params()")
@@ -1228,22 +1251,8 @@ confint.glmmTMB <- function (object, parm = NULL, level = 0.95,
             fp <- family_params(object)
             if (length(fp)>0) {
                 if (ff == "ordinal") {
-                    ## thresholds are a joint function of *all* psi
-                    ## elements (softmax), so the univariate-monotone CI
-                    ## machinery does not apply; use the delta method with
-                    ## the analytic Jacobian of
-                    ## theta_j = qlogis(cumsum(softmax(c(psi, 0)))_j)
-                    pars <- get_pars(object)
-                    tf <- unname(pars[names(pars) == "psi"])
-                    w <- exp(c(tf, 0) - max(tf, 0))
-                    s <- w / sum(w)
-                    Cj <- cumsum(s)[seq_along(tf)]
-                    J <- outer(seq_along(tf), seq_along(tf),
-                               function(j, m) s[m] * ((m <= j) - Cj[j]) /
-                                              (Cj[j] * (1 - Cj[j])))
-                    Vfull <- vcov(object, full = TRUE)
-                    vi <- match(names(fp), rownames(Vfull))
-                    se_th <- sqrt(diag(J %*% Vfull[vi, vi] %*% t(J)))
+                    ## delta-method threshold SEs (see ordinal_thresholds)
+                    se_th <- ordinal_thresholds(object)[, "Std. Error"]
                     qn <- qnorm((1 + level) / 2)
                     ci.shape <- cbind(fp - qn * se_th, fp + qn * se_th)
                     if (estimate) ci.shape <- cbind(ci.shape, fp)

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -17,6 +17,12 @@
       \code{simulate()} are supported. Nominal (category-specific) and
       scale effects are not (yet) implemented; \code{REML=TRUE} warns,
       since it integrates out the fixed effects but not the thresholds
+      \item \code{summary()} for the \code{ordinal} family reports the
+      thresholds with delta-method standard errors in a
+      \dQuote{Threshold coefficients} block (also available as the
+      \code{thresholds} element of the summary object); the threshold
+      rows of \code{vcov(., full = TRUE)} remain on the internal
+      (softmax) scale (GH #1323)
       \item Dunn-Smyth residuals (\code{type = "dunn-smyth"} in
       \code{residuals()}) are now available for the \code{bell} and
       \code{genpois} families; the Bell distribution uses internal C-level

--- a/glmmTMB/man/summary.glmmTMB.Rd
+++ b/glmmTMB/man/summary.glmmTMB.Rd
@@ -32,3 +32,11 @@ warning, because their performance (and theoretical justification) for GLMMs is 
 \description{
 summary for glmmTMB fits
 }
+\details{
+For the \code{ordinal} family, the returned object has a
+\code{thresholds} element (a matrix of threshold estimates, delta-method
+standard errors, and z values), printed as \dQuote{Threshold coefficients};
+the thresholds are estimated internally via a softmax parameterization, so
+the corresponding rows of \code{vcov(., full = TRUE)} are not on the
+threshold scale
+}

--- a/glmmTMB/tests/testthat/test-ordinal.R
+++ b/glmmTMB/tests/testthat/test-ordinal.R
@@ -79,6 +79,28 @@ test_that("ordinal mixed model matches ordinal::clmm", {
     expect_equal(unname(attr(VarCorr(fit_tmb)$cond$judge, "stddev")),
                  unname(sqrt(ordinal::VarCorr(fit_clmm)$judge[1, 1])),
                  tolerance = 1e-3)
+    ## threshold SEs on the theta scale match clmm (issue #1323)
+    expect_equal(unname(glmmTMB:::ordinal_thresholds(fit_tmb)[, "Std. Error"]),
+                 unname(sqrt(diag(vcov(fit_clmm)))[seq_along(fit_clmm$alpha)]),
+                 tolerance = 1e-3)
+})
+
+test_that("ordinal threshold standard errors (delta method)", {
+    fit_polr <- MASS::polr(Sat ~ Infl + Type + Cont, weights = Freq,
+                           data = housing, Hess = TRUE)
+    thr <- glmmTMB:::ordinal_thresholds(fit_ord)
+    expect_identical(rownames(thr), c("Low|Medium", "Medium|High"))
+    expect_equal(thr[, "Estimate"], family_params(fit_ord))
+    expect_equal(unname(thr[, "Std. Error"]),
+                 unname(summary(fit_polr)$coefficients[rownames(thr),
+                                                       "Std. Error"]),
+                 tolerance = 1e-4)
+    ## consistent with the Wald CIs from confint()
+    ci <- confint(fit_ord, component = "all")
+    expect_equal(unname(thr[, "Std. Error"]),
+                 unname((ci[rownames(thr), 2] - ci[rownames(thr), 1]) /
+                        (2 * qnorm(0.975))),
+                 tolerance = 1e-8)
 })
 
 test_that("ordinal simulate/residuals/refit", {

--- a/glmmTMB/tests/testthat/test-ordinal.R
+++ b/glmmTMB/tests/testthat/test-ordinal.R
@@ -101,6 +101,16 @@ test_that("ordinal threshold standard errors (delta method)", {
                  unname((ci[rownames(thr), 2] - ci[rownames(thr), 1]) /
                         (2 * qnorm(0.975))),
                  tolerance = 1e-8)
+    ## exposed in summary() as a separate 'thresholds' table
+    ss <- summary(fit_ord)
+    expect_identical(colnames(ss$thresholds),
+                     c("Estimate", "Std. Error", "z value"))
+    expect_equal(ss$thresholds[, c("Estimate", "Std. Error")], thr)
+    expect_false("thresholds" %in% names(ss$coefficients))
+    expect_output(print(ss), "Threshold coefficients:")
+    expect_output(print(fit_ord), "Low\\|Medium = .*Medium\\|High = ")
+    fit_pois <- glmmTMB(count ~ mined, family = poisson, data = Salamanders)
+    expect_null(summary(fit_pois)$thresholds)
 })
 
 test_that("ordinal simulate/residuals/refit", {


### PR DESCRIPTION
Closes #1323 (threshold standard errors for the ordinal family).

- Adds an internal helper `ordinal_thresholds(object)` returning the thresholds and their delta-method standard errors on the theta scale (the Jacobian previously inlined in `confint.glmmTMB`); `confint()` now uses it, so the transform lives in one place.
- `summary()` gains a `thresholds` element (Estimate / Std. Error / z value), printed as a "Threshold coefficients" block mirroring `ordinal::clm`. It is kept separate from `$coefficients` so downstream code iterating over cond/zi/disp is unaffected.
- `vcov(full = TRUE)` is left on the internal softmax scale, consistent with the `theta`/`disp` rows; documented in `?summary.glmmTMB`.
- `print()` now labels every threshold instead of only the first.
- Tests: threshold SEs checked against `MASS::polr` and `ordinal::clmm`, consistency with `confint()`'s Wald intervals, and the new summary/print output.
