### PR TITLE
emmeans: fix ddf handling for models without random effects

### DIFF
--- a/glmmTMB/R/emmeans.R
+++ b/glmmTMB/R/emmeans.R
@@ -45,6 +45,26 @@
 ##' \code{binomial} or \code{poisson} that lack one. For families other than \code{gaussian},
 ##' \code{"kenward-roger"} and \code{"satterthwaite"} are allowed but emit a warning, because
 ##' their performance (and theoretical justification) for GLMMs is poorly understood.
+##'
+##' For Gaussian models \emph{without} random effects, \code{emmeans()} defaults
+##' to the residual degrees of freedom for a plain fit, i.e. one with
+##' \code{dispformula = ~1} and an estimated dispersion parameter. Any other such
+##' fit defaults to \code{"asymptotic"} (infinite df): a non-trivial
+##' \code{dispformula}, \code{dispformula = ~0}, or a dispersion parameter held
+##' fixed via the \code{map} argument to \code{\link{glmmTMB}}. In the last case
+##' there is no variance parameter left to estimate, so the residual variance is
+##' known and the Wald statistics are exactly standard normal. (As elsewhere in
+##' \pkg{glmmTMB}, the residual degrees of freedom count the dispersion
+##' parameter, so they are one lower than \code{lm()} reports for the same
+##' fixed-effect model.) Those are defaults, as is a value taken from
+##' \code{getOption("glmmTMB.df")}; a \code{ddf} passed in the call itself is
+##' respected where possible. \code{"kenward-roger"} and \code{"satterthwaite"}
+##' need random effects, so for models without them they fall back to the
+##' residual degrees of freedom with a message, exactly as in
+##' \code{\link{summary.glmmTMB}}. That fallback also applies to a model whose
+##' dispersion parameter is fixed, where it overrides the infinite-df default
+##' described above, so that \code{emmeans()} and \code{summary()} give the same
+##' answer to the same request.
 ##' @param mod a glmmTMB model
 ##' @param component which component of the model to test/analyze ("cond", "zi", or "disp")
 ##'     or, in \pkg{emmeans} only, "response" or "cmean" as described in Details.
@@ -117,6 +137,23 @@ emm_basis.glmmTMB <- function (object, trms, xlev, grid, component = c("cond", "
     ## 1. no random effects
     fam <- family(object)$family
 
+    ## did the caller actually ask for a particular ddf in this call, or are we
+    ## falling back on the default? only the latter may be silently overridden
+    ## below. A ddf coming from getOption("glmmTMB.df") is a default, not a
+    ## request: summary()/anova()/Anova() don't read that option at all, so
+    ## treating it as a request here would make emmeans() disagree with them
+    ## whenever it is set. NB has to be evaluated before the match.arg() below,
+    ## which would make missing(ddf) FALSE
+    ddf_explicit <- !missing(ddf)
+    ## same choices as summary()/anova()/Anova(); without this an unrecognized
+    ## string silently ended up as residual df. "df.residual" is what get_ddf()
+    ## returns internally and has always been accepted here too, so keep it
+    ## working, but don't offer it as a choice: the other entry points don't
+    ## take it
+    if (!identical(ddf, "df.residual")) {
+        ddf <- match.arg(ddf, c("asymptotic", "kenward-roger", "satterthwaite"))
+    }
+
     ddf_set <- function(used, requested = ddf) {
         if (requested != used) {
             warning(gettextf("ddf '%s' specified, using ddf '%s' instead", requested, used))
@@ -129,9 +166,30 @@ emm_basis.glmmTMB <- function (object, trms, xlev, grid, component = c("cond", "
 
         if (!hasRandom(object)) {
             if (fam != "gaussian") return(ddf_set("asymptotic"))
-            if (trivialDisp(object)) return("df.residual")  ## don't want to warn here
-            if (ddf == "kenward-roger") return(ddf_set("satterthwaite"))
-            return(ddf)
+            if (!ddf_explicit) {
+                ## default: residual df for a plain LM-like fit (nobs - npar,
+                ## which counts the dispersion parameter, so one fewer than
+                ## lm() would report) -- but *not* when no dispersion
+                ## parameter is estimated at all (e.g. pinned via 'map'). The
+                ## residual variance is known then, the Wald statistics are
+                ## exactly normal, and residual df would only make the
+                ## intervals spuriously wide
+                if (trivialDisp(object) && estDisp(object)) {
+                    return("df.residual")  ## don't want to warn here
+                }
+                return("asymptotic")
+            }
+            ## an explicit request is honoured where it can be, and otherwise
+            ## downgraded through the same check_ddf() that
+            ## summary()/anova()/Anova() use, so emmeans gives the same
+            ## message and the same df instead of silently ignoring the
+            ## request (trivial dispformula) or erroring inside
+            ## GMRFmarginal() on its way through dof_satt() (non-trivial
+            ## one), which needs the joint precision matrix of a model with
+            ## random effects
+            if (ddf %in% c("asymptotic", "df.residual")) return(ddf)
+            check_ddf(object, ddf)
+            return("df.residual")
         }
 
         ## hard error (not a silent downgrade) for KR + non-REML, matching

--- a/glmmTMB/R/methods.R
+++ b/glmmTMB/R/methods.R
@@ -82,6 +82,19 @@ zeroDisp <- function(object) {
     formComp(object, "dispformula", ~0)
 }
 
+## TRUE if a dispersion parameter is actually estimated: 'betadisp' survives
+## into the fitted (post-'map') parameter vector. This is about the parameters,
+## whereas trivialDisp()/zeroDisp() are about the structure of dispformula;
+## 'map' pinning to a shared level still estimates one parameter, so it's TRUE
+estDisp <- function(object) {
+    pnames <- names(object$obj$env$par)
+    ## unusable or pre-'betadisp' parameter vector (see up2date()): assume it
+    ## was estimated, the historical assumption, rather than guessing otherwise
+    if (length(pnames) == 0 ||
+        !"betadisp" %in% names(object$obj$env$parameters)) return(TRUE)
+    "betadisp" %in% pnames
+}
+
 noZI <- function(object) {
   formComp(object, "ziformula", ~0)
 }

--- a/glmmTMB/inst/NEWS.Rd
+++ b/glmmTMB/inst/NEWS.Rd
@@ -97,6 +97,12 @@
       binomial-type models fitted with a two-column matrix
       (\code{cbind(successes, failures)}) response, matching \code{glm} and
       \code{glmer} (GH #1319)
+      \item \code{emmeans} now respects an explicitly specified \code{ddf}
+      for Gaussian models without random effects; the request was previously
+      replaced by residual df without warning, and
+      \code{"kenward-roger"}/\code{"satterthwaite"} errored for a model with
+      a non-trivial \code{dispformula} on their way into \code{dof_satt},
+      which requires random effects (Paul Schmidt)
     }
   } % bug fixes
   \subsection{USER-VISIBLE CHANGES}{
@@ -110,6 +116,18 @@
       \code{"satterthwaite"} with a warning instead); \code{"kenward-roger"}
       and \code{"satterthwaite"} on a non-Gaussian family now consistently
       emit a warning (rather than a message, or nothing) across all four
+      \item \code{emmeans} no longer reports residual degrees of freedom for
+      a Gaussian model without random effects whose dispersion parameter is
+      held fixed via \code{map}: with no variance parameter estimated the
+      residual variance is known, so \code{"asymptotic"} (infinite df) is
+      used instead (Paul Schmidt)
+      \item an unrecognized \code{ddf} string passed to \code{emmeans} is now
+      an error, as it already was in \code{summary}/\code{anova}/\code{Anova};
+      for a Gaussian model without random effects it was previously treated as
+      residual df without warning, and for the \code{zi}/\code{disp}
+      components it gave a warning and asymptotic df. Partial matches such as
+      \code{ddf = "satt"} are now accepted, as they already were in
+      \code{summary} (Paul Schmidt)
     } % itemize
   } % user-visible changes
  } % 1.1.15

--- a/glmmTMB/man/downstream_methods.Rd
+++ b/glmmTMB/man/downstream_methods.Rd
@@ -102,6 +102,26 @@ family with an estimated dispersion parameter, and throws an error for families 
 \code{binomial} or \code{poisson} that lack one. For families other than \code{gaussian},
 \code{"kenward-roger"} and \code{"satterthwaite"} are allowed but emit a warning, because
 their performance (and theoretical justification) for GLMMs is poorly understood.
+
+For Gaussian models \emph{without} random effects, \code{emmeans()} defaults
+to the residual degrees of freedom for a plain fit, i.e. one with
+\code{dispformula = ~1} and an estimated dispersion parameter. Any other such
+fit defaults to \code{"asymptotic"} (infinite df): a non-trivial
+\code{dispformula}, \code{dispformula = ~0}, or a dispersion parameter held
+fixed via the \code{map} argument to \code{\link{glmmTMB}}. In the last case
+there is no variance parameter left to estimate, so the residual variance is
+known and the Wald statistics are exactly standard normal. (As elsewhere in
+\pkg{glmmTMB}, the residual degrees of freedom count the dispersion
+parameter, so they are one lower than \code{lm()} reports for the same
+fixed-effect model.) Those are defaults, as is a value taken from
+\code{getOption("glmmTMB.df")}; a \code{ddf} passed in the call itself is
+respected where possible. \code{"kenward-roger"} and \code{"satterthwaite"}
+need random effects, so for models without them they fall back to the
+residual degrees of freedom with a message, exactly as in
+\code{\link{summary.glmmTMB}}. That fallback also applies to a model whose
+dispersion parameter is fixed, where it overrides the infinite-df default
+described above, so that \code{emmeans()} and \code{summary()} give the same
+answer to the same request.
 }
 
 \examples{

--- a/glmmTMB/tests/testthat/test-ddf.R
+++ b/glmmTMB/tests/testthat/test-ddf.R
@@ -147,4 +147,195 @@ if (requireNamespace("emmeans")) {
         expect_error(summary(salamander1_reml, ddf = "kenward-roger"), "no estimated dispersion parameter")
         expect_error(emmeans::emmeans(salamander1_reml, ~ mined, ddf = "kenward-roger"), "no estimated dispersion parameter")
     })
+
+    ## models *without* random effects: emmeans used to decide the ddf on its
+    ## own here, rather than deferring to the shared check_ddf() logic that
+    ## summary()/anova()/Anova() use
+    ss <- transform(lme4::sleepstudy,
+                    wt = 1/(1 + Days),
+                    grp = factor(Days %% 2))
+    fe_free <- glmmTMB(Reaction ~ grp, data = ss)
+    fe_pin <- glmmTMB(Reaction ~ grp, data = ss, weights = wt,
+                      start = list(betadisp = 0),
+                      map = list(betadisp = factor(NA)))
+    fe_het <- glmmTMB(Reaction ~ grp, data = ss, dispformula = ~ grp)
+
+    ## df computed from the design rather than read back from the code under
+    ## test: 2 fixed-effect coefficients, plus the dispersion parameter when
+    ## one is estimated (df.residual.glmmTMB counts it, so these are one
+    ## fewer than lm() would report)
+    n_obs <- nrow(ss)
+    df_free <- n_obs - 3     # 2 beta + betadisp
+    df_pin <- n_obs - 2      # betadisp pinned, so not counted
+
+    ## the multiplier emmeans actually used for the confidence limits. This
+    ## checks that the df emmeans *reports* is also the one it *used*, which
+    ## the df column alone does not; combined with the design-based df above
+    ## it pins the value down independently. NB with df = Inf the limits are
+    ## named asymp.LCL/asymp.UCL rather than lower.CL/upper.CL
+    ci_mult <- function(emm) {
+        s <- summary(emm)
+        upr <- s[[grep("(UCL|upper\\.CL)$", names(s))[1]]]
+        unique(round((upr - s$emmean)/s$SE, 6))
+    }
+
+    test_that("emmeans uses asymptotic df when the dispersion parameter is fixed via 'map'", {
+        expect_false(glmmTMB:::estDisp(fe_pin))
+        expect_equal(sigma(fe_pin), 1)
+        expect_equal(df.residual(fe_pin), df_pin)
+        ## no variance parameter is estimated at all, so the residual
+        ## variance is known and the Wald statistics are exactly standard
+        ## normal
+        emm <- emmeans::emmeans(fe_pin, ~ grp)
+        expect_true(all(is.infinite(summary(emm)$df)))
+        expect_equal(ci_mult(emm), round(qnorm(0.975), 6))
+    })
+
+    test_that("'map' pinning a dispersion parameter to a shared level still estimates it", {
+        ## one parameter is still estimated, so residual df stay in place
+        fe_share <- glmmTMB(Reaction ~ grp, data = ss,
+                            map = list(betadisp = factor(1)))
+        expect_true(glmmTMB:::estDisp(fe_share))
+        expect_equal(summary(emmeans::emmeans(fe_share, ~ grp))$df,
+                     rep(df_free, 2))
+        ## same for a two-parameter dispersion model collapsed to a single
+        ## shared level (as opposed to both elements pinned to NA)
+        fe_share2 <- glmmTMB(Reaction ~ grp, data = ss, dispformula = ~ grp,
+                             map = list(betadisp = factor(c(1, 1))))
+        expect_true(glmmTMB:::estDisp(fe_share2))
+        fe_pin2 <- glmmTMB(Reaction ~ grp, data = ss, dispformula = ~ grp,
+                           start = list(betadisp = c(0, 0)),
+                           map = list(betadisp = factor(c(NA, NA))))
+        expect_false(glmmTMB:::estDisp(fe_pin2))
+    })
+
+    test_that("emmeans respects an explicit ddf='asymptotic' without random effects", {
+        ## default is unchanged: residual df, quietly, with the matching
+        ## t multiplier for the confidence limits
+        expect_no_message(emm <- emmeans::emmeans(fe_free, ~ grp))
+        expect_equal(summary(emm)$df, rep(df_free, 2))
+        expect_equal(ci_mult(emm), round(qt(0.975, df_free), 6))
+        ## an explicit request was previously ignored without any warning
+        emm_as <- emmeans::emmeans(fe_free, ~ grp, ddf = "asymptotic")
+        expect_true(all(is.infinite(summary(emm_as)$df)))
+        expect_equal(ci_mult(emm_as), round(qnorm(0.975), 6))
+    })
+
+    test_that("getOption('glmmTMB.df') supplies a default, not an explicit request", {
+        ## summary()/anova()/Anova() don't read the option at all, so a value
+        ## found there must not override the no-random-effects default -- that
+        ## would make emmeans() disagree with them for anyone who has it set,
+        ## including someone who sets it to the documented default value
+        op <- options(glmmTMB.df = "asymptotic")
+        on.exit(options(op), add = TRUE)
+        expect_no_message(emm <- emmeans::emmeans(fe_free, ~ grp))
+        expect_equal(summary(emm)$df, rep(df_free, 2))
+        expect_equal(ci_mult(emm), round(qt(0.975, df_free), 6))
+        ## a standing "kenward-roger" must not produce the no-random-effects
+        ## message on every call either
+        options(glmmTMB.df = "kenward-roger")
+        expect_no_message(emm_kr <- emmeans::emmeans(fe_free, ~ grp))
+        expect_equal(summary(emm_kr)$df, rep(df_free, 2))
+    })
+
+    test_that("emmeans accepts an explicit ddf='df.residual' quietly", {
+        ## "df.residual" is what get_ddf() returns internally, and this method
+        ## has always accepted it from the user as well. It is deliberately
+        ## not one of the match.arg() choices, since summary()/anova()/Anova()
+        ## don't take it. Asking for it must not trigger the "no random
+        ## effects" message, which is about the K-R/Satterthwaite downgrade
+        expect_no_message(emm <- emmeans::emmeans(fe_free, ~ grp,
+                                                 ddf = "df.residual"))
+        expect_equal(summary(emm)$df, rep(df_free, 2))
+        ## and it is honoured even where the new default would be asymptotic:
+        ## an explicit request wins over the "nothing estimated" rule
+        expect_no_message(emm_pin <- emmeans::emmeans(fe_pin, ~ grp,
+                                                     ddf = "df.residual"))
+        expect_equal(summary(emm_pin)$df, rep(df_pin, 2))
+        expect_equal(ci_mult(emm_pin), round(qt(0.975, df_pin), 6))
+    })
+
+    test_that("emmeans rejects an unrecognized ddf instead of falling back to residual df", {
+        ## match on the list of choices rather than on match.arg()'s wording,
+        ## which is translated (the choices themselves are interpolated
+        ## verbatim, so they are locale-independent)
+        expect_error(emmeans::emmeans(fe_free, ~ grp, ddf = "no-such-ddf"),
+                     "kenward-roger")
+        ## the check happens before the component/family branches, so it also
+        ## applies to models with random effects (where the error used to come
+        ## from check_ddf() further down, with different wording) and to the
+        ## zi/disp components (which used to warn and fall back to asymptotic)
+        expect_error(emmeans::emmeans(fm1, "Days", ddf = "no-such-ddf"),
+                     "kenward-roger")
+        expect_error(emmeans::emmeans(fe_het, ~ grp, component = "disp",
+                                      ddf = "no-such-ddf"),
+                     "kenward-roger")
+    })
+
+    test_that("emmeans accepts a partial ddf match, as summary() always has", {
+        ## side effect of the new match.arg(): "satt" errored for a model with
+        ## random effects before, while summary(ddf = "satt") has always worked
+        emm_short <- emmeans::emmeans(fm1, "Days", ddf = "satt")
+        emm_full <- emmeans::emmeans(fm1, "Days", ddf = "satterthwaite")
+        expect_equal(summary(emm_short)$df, summary(emm_full)$df)
+        expect_false(any(is.infinite(summary(emm_short)$df)))
+    })
+
+    test_that("ddf for a component other than 'cond' is still asymptotic", {
+        ## unchanged behaviour, but it now passes through the new match.arg()
+        expect_true(all(is.infinite(summary(emmeans::emmeans(
+            fe_het, ~ grp, component = "disp", ddf = "asymptotic"))$df)))
+        expect_warning(emm <- emmeans::emmeans(fe_het, ~ grp,
+                                               component = "disp",
+                                               ddf = "satterthwaite"),
+                       "using ddf 'asymptotic' instead")
+        expect_true(all(is.infinite(summary(emm)$df)))
+    })
+
+    ## the two blocks below pin down emmeans behaviour that must *not* change:
+    ## their emmeans expectations hold on unpatched master too (the estDisp()
+    ## assertion below is new, since the helper itself is)
+    test_that("emmeans default for a Gaussian model with dispformula = ~0 is asymptotic", {
+        fe_zero <- glmmTMB(Reaction ~ grp, data = ss, dispformula = ~ 0)
+        expect_false(glmmTMB:::estDisp(fe_zero))
+        expect_true(all(is.infinite(summary(emmeans::emmeans(fe_zero, ~ grp))$df)))
+    })
+
+    test_that("emmeans behaviour for a non-Gaussian model without random effects is unchanged", {
+        ss$cnt <- round(ss$Reaction)
+        fe_pois <- glmmTMB(cnt ~ grp, family = poisson, data = ss)
+        ## asymptotic by default ...
+        expect_true(all(is.infinite(summary(emmeans::emmeans(fe_pois, ~ grp))$df)))
+        ## ... and an explicit kenward-roger/satterthwaite request is still
+        ## downgraded to asymptotic with a warning, before the no-random-effects
+        ## logic above is reached
+        for (dd in c("satterthwaite", "kenward-roger")) {
+            expect_warning(emm <- emmeans::emmeans(fe_pois, ~ grp, ddf = dd),
+                           "using ddf 'asymptotic' instead")
+            expect_true(all(is.infinite(summary(emm)$df)))
+        }
+    })
+
+    test_that("summary() and emmeans() agree: K-R/Satterthwaite fall back to residual df without random effects", {
+        ## df from the design: 2 fixed-effect coefficients plus however many
+        ## dispersion parameters are estimated
+        mods <- list(fe_free, fe_het, fe_pin)
+        exp_df <- c(df_free, n_obs - 4, df_pin)
+        for (dd in c("satterthwaite", "kenward-roger")) {
+            for (i in seq_along(mods)) {
+                ## dof_satt()/dof_KR() need random effects; for a non-trivial
+                ## dispformula emmeans used to reach them anyway and error,
+                ## and for a trivial one it silently ignored the request
+                expect_message(emm <- emmeans::emmeans(mods[[i]], ~ grp, ddf = dd),
+                               "no random effects in model")
+                expect_equal(summary(emm)$df, rep(exp_df[i], 2))
+                expect_equal(ci_mult(emm), round(qt(0.975, exp_df[i]), 6))
+                ## ... and that is what summary() reports too
+                expect_equal(
+                    unname(suppressMessages(
+                        summary(mods[[i]], ddf = dd)$coefficients$cond[, "ddf"])),
+                    rep(exp_df[i], 2))
+            }
+        }
+    })
 }


### PR DESCRIPTION
**This is the leftover of a case you already decided.** In #893 someone reported
that `emmeans()` used residual degrees of freedom for a glmmTMB Poisson fit
without random effects, where `glm()` reports `Inf`. Their reason was "even
when there is no dispersion parameter (and hence only fixed effects)". That was
resolved by short-circuiting every non-Gaussian family to `"asymptotic"`. A
Gaussian fit whose dispersion parameter is held fixed via `map` is the same
situation, since no variance parameter is estimated there either, but the family
test cannot see it: that takes looking at the parameter vector, which is what the
new `estDisp()` does. On master `emmeans()` reports `t` for such a fit while
`summary()` reports `z` on the same model. So the principle is not new here, only
the last case that fell through it.

**Scope.** Four `ddf` defects in the no-random-effects branch of
`emm_basis.glmmTMB()`, all Gaussian-only except the last. Throughout, *master*
means the behaviour as it stands today (`20232272`) and *this PR* the patched
behaviour:

* The fit above is the only one whose **default** output changes.
* Two more defects bite on master only when `ddf` is passed **explicitly**, on
  ordinary fits with an estimated dispersion: the request is either ignored
  without warning, or it errors out inside `dof_satt()`.
* The fourth is the missing `match.arg()`, and repairing it is **the only change
  in this PR with a footprint outside this corner**: an unrecognized `ddf`
  becomes an error for every model and component, and partial matches start
  working. Details in [What else changes](#what-else-changes).

## How I ran into it

I hit this in a meta-analysis, where the observation variances are known a priori
(`weights = 1/vi`, dispersion pinned via `map`), while cross-checking the glmmTMB
fit against `metafor::rma()`, which fits the same thing:

```r
library(glmmTMB); library(emmeans); library(metafor)
set.seed(42)
d <- expand.grid(geno = factor(c("A", "B", "C")), block = 1:4)
d$vi <- round(runif(nrow(d), 0.02, 0.30), 3)
d$yi <- rnorm(nrow(d), c(A = 4, B = 4.6, C = 5.1)[d$geno], sqrt(d$vi))

m_tmb <- glmmTMB(yi ~ geno, weights = 1/vi, data = d,
                 start = list(betadisp = 0), map = list(betadisp = factor(NA)))
m_rma <- rma(yi, vi, mods = ~ geno, data = d, method = "FE")

max(abs(fixef(m_tmb)$cond - coef(m_rma)))         #> 6.2e-08
max(abs(sqrt(diag(vcov(m_tmb)$cond)) - m_rma$se)) #> 5.5e-14   same SEs to every digit
```

The two fits agree to machine precision, so any difference downstream is a
reference-distribution difference and nothing else. `rma()` reports `z`, and so
does `summary()` (on master and unchanged by this PR):

```r
m_rma$test                          #> "z"
summary(m_tmb)$coefficients$cond
#>             Estimate Std. Error z value Pr(>|z|)
#> (Intercept)   4.0720     0.2454 16.5951   0.0000
```

`emmeans()` is the only one of the three that reports `t`, on 9 residual df:

```r
emmeans(m_tmb, ~ geno)
#> master:
#>  geno emmean    SE df lower.CL upper.CL
#>  A      4.07 0.245  9     3.52     4.63
#>  B      4.63 0.175  9     4.23     5.02
#>  C      5.34 0.198  9     4.89     5.79
#>
#> this PR:
#>  geno emmean    SE  df asymp.LCL asymp.UCL
#>  A      4.07 0.245 Inf      3.59      4.55
#>  B      4.63 0.175 Inf      4.28      4.97
#>  C      5.34 0.198 Inf      4.95      5.73

predict(m_rma, newmods = rbind(c(0, 0), c(1, 0), c(0, 1)))   ## same model, for reference
#>     pred     se  ci.lb  ci.ub
#> 1 4.0720 0.2454 3.5911 4.5529
#> 2 4.6259 0.1753 4.2823 4.9695
#> 3 5.3380 0.1981 4.9498 5.7262
```

Same estimate, same SE, different interval: on master the multiplier is
`qt(0.975, 9)` = 2.262 instead of `qnorm(0.975)` = 1.960, so every interval is 15%
too wide and the nominal 95% interval covers 97.6%. With this PR `emmeans()`
matches `summary()` and `rma()` to the printed digit.

**Why infinite df is the right answer here.** With the dispersion pinned there is
no variance parameter left to estimate. `vcov()` is then the known-weight WLS
covariance rather than an estimate carrying its own sampling variability, so
`estimate/SE` is exactly standard normal and there are no degrees of freedom to
spend. (Whether the supplied variances are themselves estimates elsewhere is a
separate question, and one that residual df do not address either, since they
scale with `n` rather than with the precision of the weights.)

## What master does today

On master, `emmeans()` reaches its own opinion instead of deferring to the shared
`check_ddf()` that `summary()`/`anova()`/`Anova()` have used since #1311. This is
the whole no-random-effects branch of `get_ddf()` in `emm_basis.glmmTMB()`, as it
stands before this PR:

```r
## master, R/emmeans.R
if (!hasRandom(object)) {
    if (fam != "gaussian") return(ddf_set("asymptotic"))
    if (trivialDisp(object)) return("df.residual")  ## don't want to warn here
    if (ddf == "kenward-roger") return(ddf_set("satterthwaite"))
    return(ddf)
}
```

Three of the four defects sit on the `trivialDisp()` line, one on the two below
it. Continuing on the data above, measured against source builds of both:

```r
m0 <- glmmTMB(yi ~ geno, weights = 1/vi, data = d)        ## dispersion estimated
d$grp <- factor(rep(1:2, 6))
mhd <- glmmTMB(yi ~ geno, dispformula = ~ grp, data = d)  ## non-trivial dispformula
dfs <- function(...) unique(summary(emmeans(...))$df)

dfs(m0, ~ geno, ddf = "asymptotic")   #> master: 8, silently  this PR: Inf
dfs(m0, ~ geno)                       #> master: 8            this PR: 8, default kept
dfs(m0, ~ geno, ddf = "asymptotick")  #> master: 8            this PR: error from match.arg
dfs(mhd, ~ geno, ddf = "satterthwaite")
#> master:  Error in seq_len(nrow(Q)) : argument must be coercible to non-negative integer
#>          (preceded by a 'length.out' warning from the same call)
#> this PR: 7   (== summary(mhd, ddf = "satterthwaite"), with the same message)
```

The four defects, all of them describing master:

1. **Residual df although no variance parameter was estimated** (the case above).
   `trivialDisp()` inspects the *structure* of `dispformula`; it cannot see the
   pin, because pinning leaves `dispformula` at `~1`.
2. **An explicit `ddf` is ignored without a warning.** The `"df.residual"` return
   deliberately bypasses `ddf_set()` so the *default* does not warn, but that
   swallows an explicit request too.
3. **An unrecognized `ddf` silently becomes residual df** in this branch, while
   models with random effects error and the `zi`/`disp` components warn.
4. **`"satterthwaite"`/`"kenward-roger"` error out** for a non-trivial
   `dispformula`. The request reaches `dof_satt()` and fails in `GMRFmarginal()`
   (`utils.R:23`), because `sdreport(getJointPrecision = TRUE)` returns no
   `jointPrecision` without random effects. `summary()` intercepts this in
   `check_ddf()` and falls back with a message, so the two interfaces disagree.
   (`dof_KR()` is never reached: `"kenward-roger"` is downgraded to
   `"satterthwaite"` one line earlier.)

## What this PR changes it to

The same branch with the patch applied, plus the two lines above it. Comments
abridged:

```r
## this PR, R/emmeans.R
## NB has to be evaluated before the match.arg() below, which would make
## missing(ddf) FALSE. A ddf from getOption("glmmTMB.df") is a default, not a
## request: summary()/anova()/Anova() don't read that option at all
ddf_explicit <- !missing(ddf)
if (!identical(ddf, "df.residual")) {
    ddf <- match.arg(ddf, c("asymptotic", "kenward-roger", "satterthwaite"))
}
## ...
if (!hasRandom(object)) {
    if (fam != "gaussian") return(ddf_set("asymptotic"))
    if (!ddf_explicit) {
        ## residual df for a plain LM-like fit, but *not* when no dispersion
        ## parameter is estimated at all
        if (trivialDisp(object) && estDisp(object)) {
            return("df.residual")  ## don't want to warn here
        }
        return("asymptotic")
    }
    ## explicit request: hand the hard cases to the same check_ddf() that
    ## summary()/anova()/Anova() use, so emmeans gives the same df and the
    ## same message instead of ignoring the request or erroring inside
    ## GMRFmarginal()
    if (ddf %in% c("asymptotic", "df.residual")) return(ddf)
    check_ddf(object, ddf)
    return("df.residual")
}
```

The patched branch splits on whether the caller asked for anything, which
separates "quietly pick a sensible default" from "honour a request or explain why
you cannot". The new `estDisp()` in `methods.R` (next to
`trivialDisp()`/`zeroDisp()`) asks the post-`map` parameter vector whether a
dispersion parameter is estimated at all; `map` pinning to a shared level rather
than to `NA` counts as estimated.

One thing I decided rather than assumed, and would happily reverse: a `ddf` found
in `getOption("glmmTMB.df")` is treated as a *default*, not as a request, so it
does not reach the explicit-request branch. Treating it as a request was my first
version and it is worse: `options(glmmTMB.df = "asymptotic")`, i.e. setting the
option to the value the signature already documents as its default, would flip
every plain Gaussian fixed-effects fit from `n - p` to `Inf`, and a standing
`"kenward-roger"` would print the "no random effects in model" message on every
`emmeans()` call. Since `summary()`/`anova()`/`Anova()` don't read the option at
all, either behaviour would be a new divergence between the entry points. As
submitted, the option behaves on master and with this PR alike.

## What else changes

Only the `match.arg()` reaches beyond Gaussian no-RE models, since it runs before
the component and family branches:

* With this PR an unrecognized `ddf` is an error everywhere. On master it depends
  on where you are: an error for models with random effects (different wording,
  from `check_ddf()`), a warning plus `asymptotic` for the `zi`/`disp`
  components, and silence plus residual df in the branch this PR is about.
* With this PR partial matches such as `ddf = "satt"` work for models with random
  effects, where master errors. That is convergence rather than collateral
  damage: `summary(m, ddf = "satt")` works on master already, because
  `summary.glmmTMB()` has had `match.arg()` all along.

For the pinned-dispersion fit, the switch to infinite df changes the *shape* of
some emmeans output, not just the numbers. Compared with master: confidence
limits are named `asymp.LCL`/`asymp.UCL` instead of `lower.CL`/`upper.CL` (so
`s$lower.CL` returns `NULL` rather than erroring), tests report `z.ratio` instead
of `t.ratio`, and `joint_tests()` gains a `Chisq` column next to `F.ratio` and
reports `df2 = Inf`. That is inherent to asymptotic inference, but worth stating.

Also worth stating: nobody is stuck on master. `emmeans(m_tmb, ~ geno, df = Inf)`
gives the right answer there today. This PR is about the default, not about
reachability.

## Left alone on purpose

* With this PR, a pinned model asked explicitly for `ddf = "satterthwaite"` still
  gets residual df, as on master, so `emmeans()` and `summary()` give the same
  answer to the same request even though the new `Inf` default argues the other
  way. Making both report `Inf` means teaching
  `check_ddf()`/`summary.glmmTMB()` about `estDisp()`, which changes `summary()`;
  happy to follow up separately.
* `ddf = "df.residual"` is exempt from the new `match.arg()`, so it keeps working
  exactly as on master. It is what `get_ddf()` returns internally and this method
  has always accepted it, but the other entry points reject it, so adding it to
  the advertised choices would re-open the divergence you closed in `a419d0c8`.
  Keeping it working is the smallest-footprint option, not necessarily the right
  one: say the word and I will drop the carve-out and let `match.arg()` be the
  single source of truth.
* The Rd now states that the residual df here count the dispersion parameter, so
  they are one lower than `lm()` reports. That only describes what
  `df.residual.glmmTMB()` does today; whether it is the right count is open in
  #1039, where you agreed `beta` should be included and pointed at the `TODO`
  above the function. I did not want to touch the counting rule in a PR about
  which distribution to use, but say the word if you would rather have the Rd
  stay silent about it.
* Two disagreements with `summary()` that exist on master and that this PR leaves
  exactly as they are, rather than changing them under cover of a bug fix. For a
  plain `glmmTMB(y ~ x)`, `summary()` reports `z` while `emmeans()` reports `t`
  on `n - p`, which is the commonest no-RE case of all. And for a non-Gaussian
  model without random effects, an explicit `"satterthwaite"` gives `summary()`
  residual df with a message but `emmeans()` `Inf` with a warning, because the
  non-Gaussian branch short-circuits one line before the one this PR touches.
  Both are worth fixing; both change more output than this PR does, so I would
  rather do them separately if you want them.

## Tests, NEWS, docs

Tests are in `test-ddf.R`; those covering changed behaviour fail on master, and
the blocks pinning down behaviour that must *not* change are labelled as such.
They check the confidence-interval multiplier (`qnorm(0.975)` versus
`qt(0.975, df)`) against degrees of freedom derived from the design rather than
read back from `df.residual()`, so the oracle is independent of the code under
test. `NEWS.Rd` and the `ddf` section of `?downstream_methods` are updated; the
behaviour-changing items are under USER-VISIBLE CHANGES. Happy to add the GH
reference to the NEWS items once this has a number.

Every `master:`/`this PR:` figure above was measured against two source builds,
one of `20232272` and one with this patch applied.

*This contribution was prepared with the assistance of an AI coding tool.*
